### PR TITLE
Added Facebook as strategy

### DIFF
--- a/packages/clerk_auth/lib/src/models/client/strategy.dart
+++ b/packages/clerk_auth/lib/src/models/client/strategy.dart
@@ -43,6 +43,9 @@ class Strategy {
   /// oauth google strategy
   static const oauthGoogle = Strategy(name: _oauth, provider: 'google');
 
+  /// oauth facebook strategy
+  static const oauthFacebook = Strategy(name: _oauth, provider: 'facebook');
+
   /// oauth token apple strategy
   static const oauthTokenApple = Strategy(name: _oauthToken, provider: 'apple');
 
@@ -51,6 +54,7 @@ class Strategy {
     oauthApple.toString(): oauthApple,
     oauthGithub.toString(): oauthGithub,
     oauthGoogle.toString(): oauthGoogle,
+    oauthFacebook.toString(): oauthFacebook,
     // 'google_one_tap': oauthGoogle, // guessing this is a synonym?
     oauthTokenApple.toString(): oauthTokenApple,
   };


### PR DESCRIPTION
Adding the facebook option to make easier the validation in the front end when the client is using custom layouts

this will help us to validate the current method using

```
Strategy.oauthFacebook
```

instead 

```
Strategy(name: 'oauth', provider: 'facebook')
```
