### PR TITLE
Fix: Route updateUserPassword errors through error stream

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -942,7 +942,7 @@ class Auth {
     String newPassword, {
     bool signOut = true,
   }) async {
-    await _api.updatePassword(currentPassword, newPassword, signOut);
+    await _api.updatePassword(currentPassword, newPassword, signOut).then(_housekeeping);
     update();
   }
 


### PR DESCRIPTION
- Ensure API errors from updateUserPassword are properly handled by _housekeeping
- This allows ClerkErrorListener to catch password validation errors
- Fixes issue where pwned password errors were logged but not catchable

Closes #278