### PR TITLE
fix: `attemptSignIn` sends password to second factor endpoint

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -538,6 +538,12 @@ class Auth {
       await _api
           .createSignIn(identifier: identifier, password: password)
           .then(_housekeeping);
+
+      // attemptSignIn needs to be called again with the second factor
+      if (signIn?.status == Status.needsSecondFactor) {
+        update();
+        return;
+      }
     }
 
     switch (client.signIn) {


### PR DESCRIPTION
Fixes #326