### PR TITLE
fix(clerk_flutter): example app working on android

### DIFF
--- a/packages/clerk_flutter/example/android/app/build.gradle
+++ b/packages/clerk_flutter/example/android/app/build.gradle
@@ -24,8 +24,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.example"
-    compileSdkVersion 35
-    ndkVersion "25.1.8937393"
+    compileSdkVersion 36
+    ndkVersion "28.2.13676358"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 23 //flutter.minSdkVersion
+        minSdkVersion flutter.minSdkVersion //flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/clerk_flutter/example/android/gradle.properties
+++ b/packages/clerk_flutter/example/android/gradle.properties
@@ -1,3 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
 android.useAndroidX=true
-android.enableJetifier=true
+# It's memory intensive and our project is already setup to use AndroidX
+android.enableJetifier=false

--- a/packages/clerk_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/clerk_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip

--- a/packages/clerk_flutter/example/android/settings.gradle
+++ b/packages/clerk_flutter/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0" // apply true
-    id "com.android.application" version "8.3.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 


### PR DESCRIPTION
Resolves #397 

This pull request updates the Android build configuration for the `clerk_flutter` example app to use newer versions of key build tools and improves build performance. The most important changes include upgrading the Gradle version, Android Gradle Plugin, compile SDK, and NDK, as well as optimizing Gradle memory settings and disabling Jetifier since the project already uses AndroidX.

**Build tool and SDK upgrades:**

* Upgraded Gradle to version `8.11.1` in `gradle-wrapper.properties` for improved build performance and compatibility.
* Updated the Android Gradle Plugin to `8.9.1` in `settings.gradle`.
* Increased `compileSdkVersion` to 36 and updated `ndkVersion` to `28.2.13676358` in `build.gradle`.
* Changed `minSdkVersion` to use the Flutter variable for better alignment with Flutter's configuration.

**Build performance and configuration:**

* Increased Gradle JVM memory allocation and disabled Jetifier in `gradle.properties` since the project already uses AndroidX, reducing unnecessary overhead.