### PR TITLE
chore: release v0.0.15-beta

### DIFF
--- a/openapi_generator/openapi-generator-config.json
+++ b/openapi_generator/openapi-generator-config.json
@@ -3,7 +3,7 @@
   "input-spec": "https://raw.githubusercontent.com/clerk/openapi-specs/refs/heads/main/bapi/2025-11-10.yml",
   "pubName": "clerk_backend_api",
   "pubDescription": "The Clerk REST Backend API. Version 2025-11-10.",
-  "pubVersion": "0.0.14-beta",
+  "pubVersion": "0.0.15-beta",
   "pubHomepage": "https://clerk.com/docs",
   "pubRepository": "https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_backend_api"
 }

--- a/packages/clerk_auth/.pubignore
+++ b/packages/clerk_auth/.pubignore
@@ -14,3 +14,4 @@ build.yaml
 
 # Test environment
 .env.test
+test/_responses

--- a/packages/clerk_auth/CHANGELOG.md
+++ b/packages/clerk_auth/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.0.15-beta
+
+* feat: add passkey support [#300] 
+* feat: add default session token template [#354]
+* feat: add metadata to sign up [#355]
+* fix: make client persist [#348]
+* feat: improve testing [#350]
+* fix: improve sign up panel [#356]
+* fix: regression introduced to pollforsessiontoken [#363
+* fix: add explicit resend code function [#365]
+* chore(clerk_auth): upgrade to api version 2025-11-10 [#371]
+* fix: consolidate oauth token sign in methods [#380]
+* fix: make sign in with apple work [#384]
+* fix: change healthcheck endpoint [#376]
+* fix(clerk_auth): unblock CORS preflight on Flutter Web [#395]
+* fix(clerk_flutter): example app working on android [#397]
+
 ## 0.0.14-beta
 
 * BREAKING CHANGE: The `ClerkDeepLink` class has been removed, since the information

--- a/packages/clerk_auth/lib/src/_version.dart
+++ b/packages/clerk_auth/lib/src/_version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.14-beta';
+const packageVersion = '0.0.15-beta';

--- a/packages/clerk_auth/pubspec.yaml
+++ b/packages/clerk_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clerk_auth
 description: Package that will allow you to authenticate and use Clerk from Dart code.
-version: 0.0.14-beta
+version: 0.0.15-beta
 homepage: https://clerk.com/docs
 repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_auth
 issue_tracker: https://github.com/clerk/clerk-sdk-flutter/labels/clerk_auth

--- a/packages/clerk_backend_api/CHANGELOG.md
+++ b/packages/clerk_backend_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.15-beta
+
+* chore: align release version with `clerk_auth` package
+
 ## 0.0.14-beta
 
 * chore: regenerate clerk_backend_api from `2025-11-10` open-api spec.

--- a/packages/clerk_backend_api/pubspec.yaml
+++ b/packages/clerk_backend_api/pubspec.yaml
@@ -3,7 +3,7 @@
 #
 
 name: 'clerk_backend_api'
-version: '0.0.14-beta'
+version: 0.0.15-beta
 description: 'The Clerk REST Backend API. Version 2025-11-10.'
 homepage: 'https://clerk.com/docs'
 repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_backend_api

--- a/packages/clerk_flutter/CHANGELOG.md
+++ b/packages/clerk_flutter/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.0.15-beta
+
+* feat: add passkey support [#300] 
+* feat: improve testing [#350]
+* fix: improve sign up panel [#356]
+* fix: add explicit resend code function [#365]
+* fix: regression in oauth sign up [#306]
+* fix: make sign in with apple work [#384] 
+* fix(clerk_flutter): phone number input field not visible [#389]
+* feat: add signing in and up to clerk_auth_builder [#382]
+
 ## 0.0.14-beta
 
 * BREAKING CHANGE: The `ClerkDeepLink` class has been removed, since the information

--- a/packages/clerk_flutter/example/pubspec.yaml
+++ b/packages/clerk_flutter/example/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  clerk_flutter: '>=0.0.14-beta'
-  clerk_auth: '>=0.0.14-beta'
+  clerk_flutter: '>=0.0.15-beta'
+  clerk_auth: '>=0.0.15-beta'
   app_links: ^3.5.1
   url_launcher_ios: 6.2.0
   google_sign_in: ^7.1.0

--- a/packages/clerk_flutter/pubspec.yaml
+++ b/packages/clerk_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clerk_flutter
 description: Package that will allow you to authenticate and use Clerk from Flutter code.
-version: 0.0.14-beta
+version: 0.0.15-beta
 homepage: https://clerk.com/docs
 repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_flutter
 issue_tracker: https://github.com/clerk/clerk-sdk-flutter/labels/clerk_flutter
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  clerk_auth: '>=0.0.14-beta <1.0.0'
+  clerk_auth: '>=0.0.15-beta <1.0.0'
   collection: '>=1.17.1 <2.0.0'
   email_validator: ^3.0.0
   flutter_svg: ^2.0.10+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clerk_sdk
-version: 0.0.14-beta
+version: 0.0.15-beta
 description: >
   Clerk SDK containing all packages that define use of Clerk 
   services for Dart and Flutter code.


### PR DESCRIPTION
This pull request updates all packages in the Clerk SDK to version `0.0.15-beta` and synchronizes their dependencies. It also adds changelog entries for the new release, documents the main new features and fixes, and improves test support. There are no breaking changes, but several enhancements and bug fixes are included, especially for authentication and testing.

**Release and Version Alignment:**

* Bump version to `0.0.15-beta` for all packages: `clerk_auth`, `clerk_backend_api`, `clerk_flutter`, and the root `clerk_sdk` package. This ensures all packages are aligned for the new release. [[1]](diffhunk://#diff-2d1a4fb9b2600f94a18e1a8c915859d03c0cd67c594d5c1405b3728b07e8d77dL3-R3) [[2]](diffhunk://#diff-5c170525df17134a59f9f021cced486868ef611ad59a35a9e18e35a6f38869c9L6-R6) [[3]](diffhunk://#diff-5fbe08b4f48b3455a101f7f85c4652660c2cc098fd18c844e13efe21fcc8f801L3-R3) [[4]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2) [[5]](diffhunk://#diff-d446dfb2fc798ba14324da1802fe41cc308a54696547c79215ee118f40f91848L2-R2) [[6]](diffhunk://#diff-6317c558136910b3af80399596d042e37f841caf9dd9b3124bd80954d716f7beL6-R6)
* Update dependencies in `clerk_flutter` and its example app to require `clerk_auth` and `clerk_flutter` version `0.0.15-beta` or higher. [[1]](diffhunk://#diff-5fbe08b4f48b3455a101f7f85c4652660c2cc098fd18c844e13efe21fcc8f801L20-R20) [[2]](diffhunk://#diff-50963234d57ee4a3b98f90204c315feb15039a06833d83a9e34cb3c72cf43b10L13-R14)

**Changelog Updates and Feature Highlights:**

* Add `CHANGELOG.md` entries for `clerk_auth`, `clerk_backend_api`, and `clerk_flutter` documenting new features (like passkey support, default session token templates, and metadata on sign up), bug fixes (including sign in with Apple, OAuth, CORS, and UI improvements), and testing enhancements. [[1]](diffhunk://#diff-9b17012aa264025f3b7bb97fc1649b8ca754bcb72b682766ceaa26783f685a07R1-R17) [[2]](diffhunk://#diff-6c742f3988c9212db709b27ae5913de198c4cb003efc01a7d9c6fb53145445f1R1-R4) [[3]](diffhunk://#diff-0938f8af7c6bd7daa48e183a6d1d90a6fbb167d4b9aa5cebc36b7fd90b9c106eR1-R11)

**Testing Improvements:**

* Add `test/_responses` to `.pubignore` in `clerk_auth` to support improved testing workflows.