### PR TITLE
fix(clerk_auth): offline sign out

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_api/api.dart
+++ b/packages/clerk_auth/lib/src/clerk_api/api.dart
@@ -164,6 +164,7 @@ class Api with Logging {
   }
 
   Future<bool> _delete(String path, {bool requiresSessionId = false}) async {
+    _tokenCache.clear();
     try {
       final headers = _headers(method: HttpMethod.delete);
       final resp = await _fetch(
@@ -173,7 +174,6 @@ class Api with Logging {
         withSession: requiresSessionId,
       );
       if (resp.statusCode == 200) {
-        _tokenCache.clear();
         return true;
       } else {
         logSevere('HTTP error on DELETE $path: ${resp.statusCode}', resp.body);

--- a/packages/clerk_auth/test/test_support/src/mock_http_service.dart
+++ b/packages/clerk_auth/test/test_support/src/mock_http_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:clerk_auth/clerk_auth.dart';
 import 'package:http/http.dart' show ByteStream, Response;
@@ -6,6 +7,10 @@ import 'package:http/http.dart' show ByteStream, Response;
 /// A mock HTTP service that returns pre-configured responses for testing
 class MockHttpService implements HttpService {
   MockHttpService();
+
+  /// When true, [send] throws a [SocketException] and [ping] returns false,
+  /// simulating a device with no network connectivity.
+  bool isOffline = false;
 
   final List<MockHttpCall> calls = [];
   final List<MockHttpResponse> responses = [];
@@ -135,6 +140,7 @@ class MockHttpService implements HttpService {
   }
 
   void reset() {
+    isOffline = false;
     calls.clear();
     responses.clear();
     _responseIndex = 0;
@@ -147,7 +153,8 @@ class MockHttpService implements HttpService {
   void terminate() {}
 
   @override
-  Future<bool> ping(Uri uri, {required Duration timeout}) => Future.value(true);
+  Future<bool> ping(Uri uri, {required Duration timeout}) =>
+      Future.value(!isOffline);
 
   @override
   Future<Response> send(
@@ -157,6 +164,7 @@ class MockHttpService implements HttpService {
     Map<String, dynamic>? params,
     String? body,
   }) async {
+    if (isOffline) throw SocketException('No network');
     calls.add(MockHttpCall(
         method: method,
         uri: uri,
@@ -496,4 +504,33 @@ extension MockHttpServiceExtensions on MockHttpService {
         'last_active_at': DateTime.now().millisecondsSinceEpoch,
         'delete_self_enabled': true,
       };
+
+  /// Add a client-with-session response that includes an Authorization response
+  /// header carrying [clientToken]. This mirrors what the real Clerk API returns
+  /// after a successful authentication: the token cache reads the client token
+  /// from the Authorization header via [TokenCache.updateFrom], so subsequent
+  /// requests from this [Auth] instance will be sent with credentials.
+  void addAuthenticatedClientWithSessionResponse({
+    String clientToken = 'test_client_token',
+    String clientId = 'client_123',
+    String sessionId = 'sess_123',
+    String userId = 'user_123',
+  }) {
+    final sessionJson = _createSessionJson(sessionId: sessionId, userId: userId);
+    final clientJson = {
+      'object': 'client',
+      'id': clientId,
+      'sessions': [sessionJson],
+      'last_active_session_id': sessionId,
+      'sign_in': null,
+      'sign_up': null,
+      'created_at': DateTime.now().millisecondsSinceEpoch,
+      'updated_at': DateTime.now().millisecondsSinceEpoch,
+    };
+    addResponse(MockHttpResponse(
+      body: jsonEncode({'response': clientJson}),
+      statusCode: 200,
+      headers: {HttpHeaders.authorizationHeader: clientToken},
+    ));
+  }
 }

--- a/packages/clerk_auth/test/test_support/src/mock_http_service.dart
+++ b/packages/clerk_auth/test/test_support/src/mock_http_service.dart
@@ -205,6 +205,7 @@ class MockHttpCall {
       this.headers,
       this.params,
       this.body});
+
   final HttpMethod method;
   final Uri uri;
   final Map<String, String>? headers;
@@ -215,6 +216,7 @@ class MockHttpCall {
 class MockHttpResponse {
   MockHttpResponse(
       {required this.body, this.statusCode = 200, this.headers = const {}});
+
   final String body;
   final int statusCode;
   final Map<String, String> headers;
@@ -516,7 +518,11 @@ extension MockHttpServiceExtensions on MockHttpService {
     String sessionId = 'sess_123',
     String userId = 'user_123',
   }) {
-    final sessionJson = _createSessionJson(sessionId: sessionId, userId: userId);
+    final sessionJson = _createSessionJson(
+      sessionId: sessionId,
+      userId: userId,
+    );
+
     final clientJson = {
       'object': 'client',
       'id': clientId,
@@ -527,6 +533,7 @@ extension MockHttpServiceExtensions on MockHttpService {
       'created_at': DateTime.now().millisecondsSinceEpoch,
       'updated_at': DateTime.now().millisecondsSinceEpoch,
     };
+
     addResponse(MockHttpResponse(
       body: jsonEncode({'response': clientJson}),
       statusCode: 200,

--- a/packages/clerk_auth/test/test_support/src/test_auth_config.dart
+++ b/packages/clerk_auth/test/test_support/src/test_auth_config.dart
@@ -2,7 +2,7 @@ import 'package:clerk_auth/clerk_auth.dart';
 import 'package:http/http.dart' show ByteStream, Response;
 
 class TestAuthConfig extends AuthConfig {
-  // A valid publishable key whose base64 payload decodes to 'somedomain.com\n'.
+  /// FAKE KEY - A valid publishable key whose base64 payload decodes to 'somedomain.com\n'.
   static const kPublishableKey = 'pk_test_c29tZWRvbWFpbi5jb20K';
 
   const TestAuthConfig({

--- a/packages/clerk_auth/test/test_support/src/test_auth_config.dart
+++ b/packages/clerk_auth/test/test_support/src/test_auth_config.dart
@@ -2,9 +2,13 @@ import 'package:clerk_auth/clerk_auth.dart';
 import 'package:http/http.dart' show ByteStream, Response;
 
 class TestAuthConfig extends AuthConfig {
+  // A valid publishable key whose base64 payload decodes to 'somedomain.com\n'.
+  static const kPublishableKey = 'pk_test_c29tZWRvbWFpbi5jb20K';
+
   const TestAuthConfig({
     required super.publishableKey,
     super.httpService = const _NoneHttpService(),
+    super.retryOptions = const RetryOptions(maxAttempts: 1),
   }) : super(
           sessionTokenPolling: false,
           localesLookup: _localesLookup,

--- a/packages/clerk_auth/test/unit/clerk_auth/sign_out_offline_test.dart
+++ b/packages/clerk_auth/test/unit/clerk_auth/sign_out_offline_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:clerk_auth/clerk_auth.dart';
+
+import '../../test_helpers.dart';
+
+void main() {
+  group('signOut offline behaviour', () {
+    late MockHttpService mockHttp;
+    late Auth auth;
+
+    setUp(() async {
+      mockHttp = MockHttpService();
+      auth = Auth(
+        config: TestAuthConfig(
+          publishableKey: TestAuthConfig.kPublishableKey,
+          httpService: mockHttp,
+        ),
+      );
+
+      // initialize() calls POST /client then GET /environment. Queue an
+      // authenticated client response (Authorization header seeds the token
+      // cache via TokenCache.updateFrom) so the session is active after init.
+      mockHttp.addAuthenticatedClientWithSessionResponse();
+      mockHttp.addEnvironmentResponse();
+      await auth.initialize();
+    });
+
+    tearDown(() {
+      auth.terminate();
+    });
+
+    test('auth is signed in after initialization with active session', () {
+      expect(auth.isSignedIn, true);
+    });
+
+    test(
+      'signOut clears local auth state immediately even when network is unavailable',
+      () async {
+        mockHttp.isOffline = true;
+
+        await auth.signOut();
+
+        expect(auth.isSignedIn, false);
+      },
+    );
+
+    // This test documents the core bug: after an offline signOut the token
+    // cache retains credentials. When connectivity returns and the background
+    // refresh fires, those credentials are sent in the Authorization header,
+    // the server recognises the still-active session and the user is silently
+    // re-authenticated.
+    //
+    // Expected behaviour: signOut() must clear the local token cache regardless
+    // of network outcome, so a subsequent refresh carries no credentials and
+    // the server returns an empty client.
+    test(
+      'after offline signOut, background client refresh does not re-authenticate the user',
+      () async {
+        mockHttp.isOffline = true;
+        await auth.signOut();
+        expect(auth.isSignedIn, false);
+
+        // Connectivity returns. Without credentials the real Clerk server returns
+        // an empty client with no active sessions.
+        mockHttp.isOffline = false;
+        mockHttp.addClientResponse();
+
+        // Simulate the background _clientTimer firing.
+        await auth.refreshClient();
+
+        expect(auth.isSignedIn, false);
+      },
+    );
+
+    test(
+      'after offline signOut, subsequent client refresh request carries no auth credentials',
+      () async {
+        mockHttp.isOffline = true;
+        await auth.signOut();
+
+        mockHttp.isOffline = false;
+        mockHttp.addClientResponse();
+        await auth.refreshClient();
+
+        final refreshCall = mockHttp.calls.last;
+        expect(refreshCall.headers?[HttpHeaders.authorizationHeader], isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Resolves #401 

This pull request addresses a critical bug in the sign-out flow when the device is offline and improves test support for simulating network conditions. The main fix ensures that local authentication state and credentials are cleared immediately during sign-out, even if the network is unavailable, preventing unintended silent re-authentication when connectivity returns. Additional changes enhance the mock HTTP service to better support offline scenarios and make tests more comprehensive and reliable.

**Bug Fixes:**
* Ensure `_tokenCache.clear()` is called at the start of the `_delete` method in `Api`, so credentials are cleared immediately during sign-out, regardless of network success or failure. [[1]](diffhunk://#diff-11037ab127182e44577cf9708b7ac1a7c9a3928795790fa10a18749d3e47727cR167) [[2]](diffhunk://#diff-11037ab127182e44577cf9708b7ac1a7c9a3928795790fa10a18749d3e47727cL176)

**Test Infrastructure Improvements:**
* Add the `isOffline` flag to `MockHttpService` to simulate offline behavior, causing network calls to throw a `SocketException` and `ping` to return `false`. [[1]](diffhunk://#diff-0f32a00ace7ace399197af5bf598164d4e702d0c6e5bac9951ba49a55347e8cbR11-R14) [[2]](diffhunk://#diff-0f32a00ace7ace399197af5bf598164d4e702d0c6e5bac9951ba49a55347e8cbL150-R157) [[3]](diffhunk://#diff-0f32a00ace7ace399197af5bf598164d4e702d0c6e5bac9951ba49a55347e8cbR167)
* Add a helper method `addAuthenticatedClientWithSessionResponse` to `MockHttpService` for easier setup of authenticated client states in tests.
* Ensure `reset()` also resets the `isOffline` flag in `MockHttpService`.

**New Tests:**
* Add `sign_out_offline_test.dart` to verify that signing out while offline clears credentials and prevents silent re-authentication when connectivity returns, and that no credentials are sent in subsequent requests.

**Test Configuration:**
* Add a valid test publishable key constant and set default retry options in `TestAuthConfig` for more predictable test behavior.