### PR TITLE
Discord (support → community), X, and support email updates

### DIFF
--- a/packages/clerk_auth/README.md
+++ b/packages/clerk_auth/README.md
@@ -6,9 +6,9 @@
 
 [![Pub Version](https://img.shields.io/pub/v/clerk_auth?color=blueviolet)](https://pub.dev/packages/clerk_auth)
 [![Pub Points](https://img.shields.io/pub/points/clerk_auth?label=pub%20points)](https://pub.dev/packages/clerk_auth/score)
-[![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://discord.com/invite/b5rXHjAg7A)
+[![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
+[![twitter](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️

--- a/packages/clerk_auth/README.md
+++ b/packages/clerk_auth/README.md
@@ -8,7 +8,7 @@
 [![Pub Points](https://img.shields.io/pub/points/clerk_auth?label=pub%20points)](https://pub.dev/packages/clerk_auth/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![twitter](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
+[![x](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️

--- a/packages/clerk_auth/README.md
+++ b/packages/clerk_auth/README.md
@@ -8,7 +8,7 @@
 [![Pub Points](https://img.shields.io/pub/points/clerk_auth?label=pub%20points)](https://pub.dev/packages/clerk_auth/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![x](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
+[![Follow on X](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️

--- a/packages/clerk_flutter/README.md
+++ b/packages/clerk_flutter/README.md
@@ -6,9 +6,9 @@
 
 [![Pub Version](https://img.shields.io/pub/v/clerk_flutter?color=blueviolet)](https://pub.dev/packages/clerk_flutter)
 [![Pub Points](https://img.shields.io/pub/points/clerk_flutter?label=pub%20points)](https://pub.dev/packages/clerk_flutter/score)
-[![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://discord.com/invite/b5rXHjAg7A)
+[![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![twitter](https://img.shields.io/twitter/follow/ClerkDev?style=social)](https://twitter.com/intent/follow?screen_name=ClerkDev)
+[![twitter](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️

--- a/packages/clerk_flutter/README.md
+++ b/packages/clerk_flutter/README.md
@@ -8,7 +8,7 @@
 [![Pub Points](https://img.shields.io/pub/points/clerk_flutter?label=pub%20points)](https://pub.dev/packages/clerk_flutter/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![twitter](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
+[![x](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️

--- a/packages/clerk_flutter/README.md
+++ b/packages/clerk_flutter/README.md
@@ -8,7 +8,7 @@
 [![Pub Points](https://img.shields.io/pub/points/clerk_flutter?label=pub%20points)](https://pub.dev/packages/clerk_flutter/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
 [![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
-[![x](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
+[![Follow on X](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️


### PR DESCRIPTION
## Summary

## Why

Clerk Discord support officially ends **2026-06-15**. After that date, Discord is a community space only — all support will then route through `clerk.com/contact/support` or `support@clerk.com`.

This PR aligns this repo's copy and links with that change. While in the same files, it also fixes adjacent updates for our X.com handle and support email.

## Changes (if needed)

1. **Discord framing** → community framing only. Never described as "support thread", "support channel", or as a place to "get help".
2. **Discord URL** → Use `https://clerk.com/discord` instead of direct invitation URL.
3. **Help/support links** → `https://clerk.com/contact/support` or `support@clerk.com`. Also updating `support@clerk.dev` → `support@clerk.com`.
4. **Twitter/X URLs** → Changes `twitter.com` → `x.com` and `@ClerkDev` → `@clerk` on Clerk-owned URLs only. Third-party author handles, OAuth-protocol examples, and quoted-tweet permalinks intentionally untouched.

## Companion PRs

- **AutoMap**: https://github.com/clerk/AutoMap/pull/49
- **api-keys-shadcn-demo**: https://github.com/clerk/api-keys-shadcn-demo/pull/2
- **cached-pricing-table**: https://github.com/clerk/cached-pricing-table/pull/3
- **clerk**: https://github.com/clerk/clerk/pull/2639
- **clerk-android**: https://github.com/clerk/clerk-android/pull/662
- **clerk-astro-quickstart**: https://github.com/clerk/clerk-astro-quickstart/pull/15
- **clerk-b2b-saas-starter**: https://github.com/clerk/clerk-b2b-saas-starter/pull/6
- **clerk-chrome-extension-demo**: https://github.com/clerk/clerk-chrome-extension-demo/pull/174
- **clerk-chrome-extension-quickstart**: https://github.com/clerk/clerk-chrome-extension-quickstart/pull/8
- **clerk-docs**: https://github.com/clerk/clerk-docs/pull/3392
- **clerk-expo-quickstart**: https://github.com/clerk/clerk-expo-quickstart/pull/45
- **clerk-express-quickstart**: https://github.com/clerk/clerk-express-quickstart/pull/6
- **clerk-fastify-quickstart**: https://github.com/clerk/clerk-fastify-quickstart/pull/10
- **clerk-ios**: https://github.com/clerk/clerk-ios/pull/419
- **clerk-javascript-quickstart**: https://github.com/clerk/clerk-javascript-quickstart/pull/4
- **clerk-multidomain-demo**: https://github.com/clerk/clerk-multidomain-demo/pull/197
- **clerk-nextjs-app-quickstart**: https://github.com/clerk/clerk-nextjs-app-quickstart/pull/39
- **clerk-nextjs-onboarding-sample-app**: https://github.com/clerk/clerk-nextjs-onboarding-sample-app/pull/15
- **clerk-nextjs-pages-quickstart**: https://github.com/clerk/clerk-nextjs-pages-quickstart/pull/15
- **clerk-nextjs-quickstart-demo-app**: https://github.com/clerk/clerk-nextjs-quickstart-demo-app/pull/5
- **clerk-nextjs-trpc-drizzle**: https://github.com/clerk/clerk-nextjs-trpc-drizzle/pull/5
- **clerk-nextjs-trpc-prisma**: https://github.com/clerk/clerk-nextjs-trpc-prisma/pull/6
- **clerk-nuxt-quickstart**: https://github.com/clerk/clerk-nuxt-quickstart/pull/12
- **clerk-react-quickstart**: https://github.com/clerk/clerk-react-quickstart/pull/13
- **clerk-react-router-quickstart**: https://github.com/clerk/clerk-react-router-quickstart/pull/10
- **clerk-sdk-go**: https://github.com/clerk/clerk-sdk-go/pull/561
- **clerk-sdk-php**: https://github.com/clerk/clerk-sdk-php/pull/76
- **clerk-sdk-python**: https://github.com/clerk/clerk-sdk-python/pull/232
- **clerk-supabase-nextjs**: https://github.com/clerk/clerk-supabase-nextjs/pull/8
- **clerk-tanstack-react-start-quickstart**: https://github.com/clerk/clerk-tanstack-react-start-quickstart/pull/11
- **clerk-vue-quickstart**: https://github.com/clerk/clerk-vue-quickstart/pull/6
- **dashboard**: https://github.com/clerk/dashboard/pull/9328
- **demo-api-keys**: https://github.com/clerk/demo-api-keys/pull/3
- **demos**: https://github.com/clerk/demos/pull/1
- **easie**: https://github.com/clerk/easie/pull/28
- **examples**: https://github.com/clerk/examples/pull/76
- **javascript**: https://github.com/clerk/javascript/pull/8650
- **launch-darker**: https://github.com/clerk/launch-darker/pull/6
- **lead-agent**: https://github.com/clerk/lead-agent/pull/24
- **mcp-tools**: https://github.com/clerk/mcp-tools/pull/29
- **nextjs-auth-starter-template**: https://github.com/clerk/nextjs-auth-starter-template/pull/56
- **pkglab**: https://github.com/clerk/pkglab/pull/23
- **skills**: https://github.com/clerk/skills/pull/47
- **support-tools**: https://github.com/clerk/support-tools/pull/1493
- **v0-b2b-saas-template-8j**: https://github.com/clerk/v0-b2b-saas-template-8j/pull/4
