### PR TITLE
feat: client trust

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -610,7 +610,7 @@ class Auth {
         }
 
       case SignIn signIn
-          when signIn.status.needsFactor &&
+          when signIn.needsFirstFactor &&
               strategy.isPassword &&
               password is String:
         await _api

--- a/packages/clerk_auth/lib/src/models/client/sign_in.dart
+++ b/packages/clerk_auth/lib/src/models/client/sign_in.dart
@@ -83,6 +83,7 @@ class SignIn extends AuthObject with InformativeToStringMixin {
     return switch (status) {
       Status.needsFirstFactor => firstFactorVerification,
       Status.needsSecondFactor => secondFactorVerification,
+      Status.needsClientTrust => secondFactorVerification,
       _ => firstFactorVerification ?? secondFactorVerification,
     };
   }
@@ -100,8 +101,13 @@ class SignIn extends AuthObject with InformativeToStringMixin {
   /// Do we need a second factor?
   bool get needsSecondFactor => status == Status.needsSecondFactor;
 
+  /// Do we need client trust?
+  bool get needsClientTrust => status == Status.needsClientTrust;
+
   /// Do we need a factor?
-  bool get needsFactor => needsFirstFactor || needsSecondFactor;
+  bool get needsFactor {
+    return needsFirstFactor || needsSecondFactor || needsClientTrust;
+  }
 
   /// Is this [SignIn] transferable to a [SignUp]?
   bool get isTransferable => verification?.status.isTransferable == true;

--- a/packages/clerk_auth/lib/src/models/enums.dart
+++ b/packages/clerk_auth/lib/src/models/enums.dart
@@ -89,6 +89,7 @@ enum Stage {
     return switch (status) {
       Status.needsFirstFactor => first,
       Status.needsSecondFactor => second,
+      Status.needsClientTrust => second,
       _ => throw ClerkError(
           message: 'No Stage for {arg}',
           argument: status.toString(),

--- a/packages/clerk_auth/lib/src/models/status.dart
+++ b/packages/clerk_auth/lib/src/models/status.dart
@@ -36,6 +36,9 @@ class Status {
   /// needs second factor
   static const needsSecondFactor = Status._('needs_second_factor');
 
+  /// needs client trust
+  static const needsClientTrust = Status._('needs_client_trust');
+
   /// transferable
   static const transferable = Status._('transferable');
 
@@ -65,6 +68,7 @@ class Status {
     needsIdentifier.name: needsIdentifier,
     needsFirstFactor.name: needsFirstFactor,
     needsSecondFactor.name: needsSecondFactor,
+    needsClientTrust.name: needsClientTrust,
     transferable.name: transferable,
     unverified.name: unverified,
     verified.name: verified,
@@ -102,7 +106,10 @@ class Status {
   bool get isUnverified => this == unverified;
 
   /// needs factor?
-  bool get needsFactor => this == needsFirstFactor || this == needsSecondFactor;
+  bool get needsFactor =>
+      this == needsFirstFactor ||
+      this == needsSecondFactor ||
+      this == needsClientTrust;
 
   /// Do we need factors for this stage?
   bool needsFactorFor(Stage stage) => switch (stage) {

--- a/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/001.json
+++ b/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/001.json
@@ -1,0 +1,19 @@
+{
+  "key": "POST /v1/client",
+  "body": {
+    "response": {
+      "object": "client",
+      "id": "CLIENT_ID",
+      "sessions": [],
+      "sign_in": null,
+      "sign_up": null,
+      "last_active_session_id": null,
+      "last_authentication_strategy": null,
+      "cookie_expires_at": null,
+      "captcha_bypass": false,
+      "created_at": "%%DATETIME -4%%",
+      "updated_at": "%%DATETIME -2%%"
+    },
+    "client": null
+  }
+}

--- a/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/002.json
+++ b/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/002.json
@@ -1,0 +1,350 @@
+{
+  "key": "GET /v1/environment",
+  "body": {
+    "auth_config": {
+      "object": "auth_config",
+      "id": "AUTH_CONFIG_ID",
+      "first_name": "%%FIRSTNAME%%",
+      "last_name": "%%LASTNAME%%",
+      "email_address": "%%EMAIL%%",
+      "phone_number": "off",
+      "username": "off",
+      "password": "required",
+      "identification_requirements": [
+        [
+          "email_address",
+          "oauth_google"
+        ],
+        []
+      ],
+      "identification_strategies": [
+        "email_address",
+        "oauth_google"
+      ],
+      "first_factors": [
+        "email_code",
+        "oauth_google",
+        "password",
+        "reset_password_email_code",
+        "ticket"
+      ],
+      "second_factors": [],
+      "email_address_verification_strategies": [
+        "email_code"
+      ],
+      "single_session_mode": true,
+      "enhanced_email_deliverability": false,
+      "test_mode": true,
+      "cookieless_dev": true,
+      "url_based_session_syncing": true,
+      "claimed_at": null,
+      "reverification": true
+    },
+    "display_config": {
+      "object": "display_config",
+      "id": "DISPLAY_CONFIG_ID",
+      "instance_environment_type": "development",
+      "application_name": "APPLICATION_NAME",
+      "theme": {
+        "buttons": {
+          "font_color": "#ffffff",
+          "font_family": "\"Source Sans Pro\", sans-serif",
+          "font_weight": "600"
+        },
+        "general": {
+          "color": "#6c47ff",
+          "padding": "1em",
+          "box_shadow": "0 2px 8px rgba(0, 0, 0, 0.2)",
+          "font_color": "#151515",
+          "font_family": "\"Source Sans Pro\", sans-serif",
+          "border_radius": "0.5em",
+          "background_color": "#ffffff",
+          "label_font_weight": "600"
+        },
+        "accounts": {
+          "background_color": "#ffffff"
+        }
+      },
+      "preferred_sign_in_strategy": "password",
+      "logo_image_url": "",
+      "favicon_image_url": "",
+      "home_url": "URL",
+      "sign_in_url": "URL",
+      "sign_up_url": "URL",
+      "user_profile_url": "URL",
+      "waitlist_url": "URL",
+      "after_sign_in_url": "URL",
+      "after_sign_up_url": "URL",
+      "after_sign_out_one_url": "URL",
+      "after_sign_out_all_url": "URL",
+      "after_switch_session_url": "URL",
+      "after_join_waitlist_url": "URL",
+      "organization_profile_url": "URL",
+      "create_organization_url": "URL",
+      "after_leave_organization_url": "URL",
+      "after_create_organization_url": "URL",
+      "logo_link_url": "URL",
+      "support_email": null,
+      "branded": true,
+      "experimental_force_oauth_first": false,
+      "clerk_js_version": "6",
+      "show_devmode_warning": true,
+      "google_one_tap_client_id": null,
+      "help_url": null,
+      "privacy_policy_url": null,
+      "terms_url": null,
+      "logo_url": null,
+      "favicon_url": null,
+      "logo_image": null,
+      "favicon_image": null,
+      "captcha_public_key": null,
+      "captcha_widget_type": null,
+      "captcha_public_key_invisible": null,
+      "captcha_provider": null,
+      "captcha_oauth_bypass": []
+    },
+    "user_settings": {
+      "attributes": {
+        "email_address": {
+          "enabled": true,
+          "required": true,
+          "used_for_first_factor": true,
+          "first_factors": [
+            "email_code"
+          ],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [
+            "email_code"
+          ],
+          "verify_at_sign_up": true,
+          "immutable": false
+        },
+        "phone_number": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "username": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "web3_wallet": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "first_name": {
+          "enabled": true,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "last_name": {
+          "enabled": true,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "password": {
+          "enabled": true,
+          "required": true,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "authenticator_app": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "ticket": {
+          "enabled": true,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "backup_code": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        },
+        "passkey": {
+          "enabled": false,
+          "required": false,
+          "used_for_first_factor": false,
+          "first_factors": [],
+          "used_for_second_factor": false,
+          "second_factors": [],
+          "verifications": [],
+          "verify_at_sign_up": false,
+          "immutable": false
+        }
+      },
+      "sign_in": {
+        "second_factor": {
+          "required": false
+        }
+      },
+      "sign_up": {
+        "captcha_enabled": true,
+        "captcha_widget_type": "smart",
+        "custom_action_required": false,
+        "progressive": true,
+        "mode": "public",
+        "legal_consent_enabled": false,
+        "mfa": {
+          "required": false
+        }
+      },
+      "restrictions": {
+        "allowlist": {
+          "enabled": false
+        },
+        "blocklist": {
+          "enabled": false
+        },
+        "allowlist_blocklist_disabled_on_sign_in": {
+          "enabled": true
+        },
+        "block_email_subaddresses": {
+          "enabled": false
+        },
+        "block_disposable_email_domains": {
+          "enabled": false
+        }
+      },
+      "username_settings": {
+        "min_length": 4,
+        "max_length": 64,
+        "allow_extended_special_characters": false,
+        "allow_numeric_usernames": false
+      },
+      "actions": {
+        "delete_self": true,
+        "create_organization": true,
+        "create_organizations_limit": null
+      },
+      "attack_protection": {
+        "user_lockout": {
+          "enabled": true,
+          "max_attempts": 100,
+          "duration_in_minutes": 60
+        },
+        "pii": {
+          "enabled": true
+        },
+        "email_link": {
+          "require_same_client": true
+        },
+        "enumeration_protection": {
+          "enabled": false
+        }
+      },
+      "passkey_settings": {
+        "allow_autofill": true,
+        "show_sign_in_button": true
+      },
+      "social": {
+        "oauth_google": {
+          "enabled": true,
+          "required": false,
+          "authenticatable": true,
+          "block_email_subaddresses": true,
+          "strategy": "oauth_google",
+          "not_selectable": false,
+          "deprecated": false,
+          "name": "Google",
+          "logo_url": "URL"
+        }
+      },
+      "password_settings": {
+        "disable_hibp": false,
+        "min_length": 0,
+        "max_length": 0,
+        "require_special_char": false,
+        "require_numbers": false,
+        "require_uppercase": false,
+        "require_lowercase": false,
+        "show_zxcvbn": true,
+        "min_zxcvbn_strength": 2,
+        "enforce_hibp_on_sign_in": true,
+        "allowed_special_characters": "+$-_"
+      }
+    },
+    "commerce_settings": {
+      "billing": {
+        "enabled": false,
+        "has_paid_user_plans": false,
+        "has_paid_org_plans": false,
+        "free_trial_requires_payment_method": true,
+        "user": {
+          "enabled": false,
+          "has_paid_plans": false
+        },
+        "organization": {
+          "enabled": false,
+          "has_paid_plans": false
+        }
+      }
+    },
+    "api_keys_settings": {
+      "enabled": false,
+      "USER_ID": false,
+      "orgs_api_keys_enabled": false
+    },
+    "maintenance_mode": false,
+    "client_debug_mode": false,
+    "partitioned_cookies": false
+  }
+}

--- a/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/003.json
+++ b/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/003.json
@@ -1,0 +1,109 @@
+{
+  "key": "POST /v1/client/sign_ins identifier&password",
+  "body": {
+    "response": {
+      "object": "sign_in_attempt",
+      "id": "SIGN_IN_ID",
+      "status": "needs_client_trust",
+      "supported_identifiers": [
+        "email_address"
+      ],
+      "supported_first_factors": [
+        {
+          "strategy": "password"
+        },
+        {
+          "strategy": "email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        },
+        {
+          "strategy": "reset_password_email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        }
+      ],
+      "supported_second_factors": [
+        {
+          "strategy": "email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        }
+      ],
+      "first_factor_verification": {
+        "object": "verification_password",
+        "status": "verified",
+        "strategy": "password",
+        "attempts": 1,
+        "expire_at": null
+      },
+      "second_factor_verification": null,
+      "identifier": "%%EMAIL%%",
+      "user_data": null,
+      "created_session_id": null,
+      "abandon_at": "%%DATETIME 2%%",
+      "locale": null
+    },
+    "client": {
+      "object": "client",
+      "id": "CLIENT_ID",
+      "sessions": [],
+      "sign_in": {
+        "object": "sign_in_attempt",
+        "id": "SIGN_IN_ID",
+        "status": "needs_client_trust",
+        "supported_identifiers": [
+          "email_address"
+        ],
+        "supported_first_factors": [
+          {
+            "strategy": "password"
+          },
+          {
+            "strategy": "email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          },
+          {
+            "strategy": "reset_password_email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          }
+        ],
+        "supported_second_factors": [
+          {
+            "strategy": "email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          }
+        ],
+        "first_factor_verification": {
+          "object": "verification_password",
+          "status": "verified",
+          "strategy": "password",
+          "attempts": 1,
+          "expire_at": null
+        },
+        "second_factor_verification": null,
+        "identifier": "%%EMAIL%%",
+        "user_data": null,
+        "created_session_id": null,
+        "abandon_at": "%%DATETIME 2%%",
+        "locale": null
+      },
+      "sign_up": null,
+      "last_active_session_id": null,
+      "last_authentication_strategy": null,
+      "cookie_expires_at": null,
+      "captcha_bypass": false,
+      "created_at": "%%DATETIME -4%%",
+      "updated_at": "%%DATETIME -2%%"
+    }
+  }
+}

--- a/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/004.json
+++ b/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/004.json
@@ -1,0 +1,121 @@
+{
+  "key": "POST /v1/client/sign_ins/SIGN_IN_ID/prepare_second_factor email_address_id=IDENTIFIER_ID&strategy=email_code",
+  "body": {
+    "response": {
+      "object": "sign_in_attempt",
+      "id": "SIGN_IN_ID",
+      "status": "needs_client_trust",
+      "supported_identifiers": [
+        "email_address"
+      ],
+      "supported_first_factors": [
+        {
+          "strategy": "password"
+        },
+        {
+          "strategy": "email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        },
+        {
+          "strategy": "reset_password_email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        }
+      ],
+      "supported_second_factors": [
+        {
+          "strategy": "email_code",
+          "safe_identifier": "%%EMAIL%%",
+          "email_address_id": "IDENTIFIER_ID",
+          "primary": true
+        }
+      ],
+      "first_factor_verification": {
+        "object": "verification_password",
+        "status": "verified",
+        "strategy": "password",
+        "attempts": 1,
+        "expire_at": null
+      },
+      "second_factor_verification": {
+        "object": "verification_otp",
+        "status": "unverified",
+        "strategy": "email_code",
+        "attempts": 0,
+        "expire_at": "%%DATETIME 1%%"
+      },
+      "identifier": "%%EMAIL%%",
+      "user_data": null,
+      "created_session_id": null,
+      "abandon_at": "%%DATETIME 2%%",
+      "locale": null
+    },
+    "client": {
+      "object": "client",
+      "id": "CLIENT_ID",
+      "sessions": [],
+      "sign_in": {
+        "object": "sign_in_attempt",
+        "id": "SIGN_IN_ID",
+        "status": "needs_client_trust",
+        "supported_identifiers": [
+          "email_address"
+        ],
+        "supported_first_factors": [
+          {
+            "strategy": "password"
+          },
+          {
+            "strategy": "email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          },
+          {
+            "strategy": "reset_password_email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          }
+        ],
+        "supported_second_factors": [
+          {
+            "strategy": "email_code",
+            "safe_identifier": "%%EMAIL%%",
+            "email_address_id": "IDENTIFIER_ID",
+            "primary": true
+          }
+        ],
+        "first_factor_verification": {
+          "object": "verification_password",
+          "status": "verified",
+          "strategy": "password",
+          "attempts": 1,
+          "expire_at": null
+        },
+        "second_factor_verification": {
+          "object": "verification_otp",
+          "status": "unverified",
+          "strategy": "email_code",
+          "attempts": 0,
+          "expire_at": "%%DATETIME 1%%"
+        },
+        "identifier": "%%EMAIL%%",
+        "user_data": null,
+        "created_session_id": null,
+        "abandon_at": "%%DATETIME 2%%",
+        "locale": null
+      },
+      "sign_up": null,
+      "last_active_session_id": null,
+      "last_authentication_strategy": null,
+      "cookie_expires_at": null,
+      "captcha_bypass": false,
+      "created_at": "%%DATETIME -4%%",
+      "updated_at": "%%DATETIME -2%%"
+    }
+  }
+}

--- a/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/005.json
+++ b/packages/clerk_auth/test/_responses/clerk_auth/sign_in_test/sign_in_with_client_trust/005.json
@@ -1,0 +1,140 @@
+{
+  "key": "POST /v1/client/sign_ins/SIGN_IN_ID/attempt_second_factor code=424242&strategy=email_code",
+  "body": {
+    "response": {
+      "object": "sign_in_attempt",
+      "id": "SIGN_IN_ID",
+      "status": "complete",
+      "supported_identifiers": [
+        "email_address"
+      ],
+      "supported_first_factors": null,
+      "supported_second_factors": null,
+      "first_factor_verification": {
+        "object": "verification_password",
+        "status": "verified",
+        "strategy": "password",
+        "attempts": 1,
+        "expire_at": null
+      },
+      "second_factor_verification": {
+        "object": "verification_otp",
+        "status": "verified",
+        "strategy": "email_code",
+        "attempts": 1,
+        "expire_at": "%%DATETIME 1%%"
+      },
+      "identifier": "%%EMAIL%%",
+      "user_data": null,
+      "created_session_id": "SESSION_ID",
+      "abandon_at": "%%DATETIME 2%%",
+      "locale": null
+    },
+    "client": {
+      "object": "client",
+      "id": "CLIENT_ID",
+      "sessions": [
+        {
+          "object": "session",
+          "id": "SESSION_ID",
+          "status": "active",
+          "expire_at": "%%DATETIME 1%%",
+          "abandon_at": "%%DATETIME 2%%",
+          "last_active_at": "%%DATETIME -3%%",
+          "last_active_organization_id": null,
+          "actor": null,
+          "user": {
+            "id": "USER_ID",
+            "object": "user",
+            "username": null,
+            "first_name": "%%FIRSTNAME%%",
+            "last_name": "%%LASTNAME%%",
+            "locale": null,
+            "image_url": "URL",
+            "has_image": false,
+            "primary_email_address_id": "IDENTIFIER_ID",
+            "primary_phone_number_id": null,
+            "primary_web3_wallet_id": null,
+            "password_enabled": true,
+            "two_factor_enabled": false,
+            "totp_enabled": false,
+            "backup_code_enabled": false,
+            "email_addresses": [
+              {
+                "id": "IDENTIFIER_ID",
+                "object": "email_address",
+                "email_address": "%%EMAIL%%",
+                "reserved": false,
+                "verification": {
+                  "object": "verification_admin",
+                  "status": "verified",
+                  "strategy": "admin",
+                  "attempts": null,
+                  "expire_at": null
+                },
+                "linked_to": [],
+                "matches_sso_connection": false,
+                "created_at": "%%DATETIME -4%%",
+                "updated_at": "%%DATETIME -2%%"
+              }
+            ],
+            "phone_numbers": [],
+            "web3_wallets": [],
+            "passkeys": [],
+            "external_accounts": [],
+            "saml_accounts": [],
+            "enterprise_accounts": [],
+            "password_last_updated_at": "%%DATETIME -2%%",
+            "public_metadata": {},
+            "unsafe_metadata": {},
+            "external_id": null,
+            "last_sign_in_at": "%%DATETIME -2%%",
+            "banned": false,
+            "locked": false,
+            "lockout_expires_in_seconds": null,
+            "verification_attempts_remaining": 100,
+            "created_at": "%%DATETIME -4%%",
+            "updated_at": "%%DATETIME -2%%",
+            "delete_self_enabled": true,
+            "bypass_client_trust": false,
+            "create_organization_enabled": true,
+            "last_active_at": "%%DATETIME -3%%",
+            "mfa_enabled_at": null,
+            "mfa_disabled_at": null,
+            "legal_accepted_at": null,
+            "deprovisioned": false,
+            "profile_image_url": "URL",
+            "organization_memberships": []
+          },
+          "public_user_data": {
+            "first_name": "%%FIRSTNAME%%",
+            "last_name": "%%LASTNAME%%",
+            "image_url": "URL",
+            "has_image": false,
+            "identifier": "%%EMAIL%%",
+            "username": null,
+            "profile_image_url": "URL"
+          },
+          "factor_verification_age": [
+            0,
+            0
+          ],
+          "created_at": "%%DATETIME -4%%",
+          "updated_at": "%%DATETIME -2%%",
+          "last_active_token": {
+            "object": "token",
+            "jwt": "e30=.e30=.e30="
+          }
+        }
+      ],
+      "sign_in": null,
+      "sign_up": null,
+      "last_active_session_id": "SESSION_ID",
+      "last_authentication_strategy": "password",
+      "cookie_expires_at": null,
+      "captcha_bypass": false,
+      "created_at": "%%DATETIME -4%%",
+      "updated_at": "%%DATETIME -2%%"
+    }
+  }
+}

--- a/packages/clerk_auth/test/integration/clerk_auth/sign_in_test.dart
+++ b/packages/clerk_auth/test/integration/clerk_auth/sign_in_test.dart
@@ -81,6 +81,32 @@ void main() {
       });
     });
 
+    test('can sign in with password then client trust email code', () async {
+      await runWithLogging(() async {
+        await initialiseForTest('sign_in_with_client_trust');
+
+        expect(auth.user, null);
+        await auth.attemptSignIn(
+          identifier: env.email,
+          strategy: Strategy.password,
+          password: env.password,
+        );
+        expect(auth.signIn?.status, Status.needsClientTrust);
+
+        await auth.attemptSignIn(strategy: Strategy.emailCode);
+        expect(auth.signIn?.status, Status.needsClientTrust);
+
+        await auth.attemptSignIn(
+          strategy: Strategy.emailCode,
+          code: env.code,
+        );
+        expect(auth.signIn, null);
+        expect(auth.user is User);
+
+        expect(httpService.isCompleted);
+      });
+    });
+
     test('can sign in with email link', () async {
       await runWithLogging(() async {
         await initialiseForTest('sign_in_with_email_link');

--- a/packages/clerk_auth/test/unit/models/status_test.dart
+++ b/packages/clerk_auth/test/unit/models/status_test.dart
@@ -23,6 +23,7 @@ void main() {
       expect(Status(name: 'needs_identifier'), Status.needsIdentifier);
       expect(Status(name: 'needs_first_factor'), Status.needsFirstFactor);
       expect(Status(name: 'needs_second_factor'), Status.needsSecondFactor);
+      expect(Status(name: 'needs_client_trust'), Status.needsClientTrust);
       expect(Status(name: 'transferable'), Status.transferable);
       expect(Status(name: 'unverified'), Status.unverified);
       expect(Status(name: 'verified'), Status.verified);
@@ -66,9 +67,12 @@ void main() {
       expect(Status.active.isTransferable, false);
     });
 
-    test('needsFactor returns true for first and second factor statuses', () {
+    test(
+        'needsFactor returns true for first, second, and client trust statuses',
+        () {
       expect(Status.needsFirstFactor.needsFactor);
       expect(Status.needsSecondFactor.needsFactor);
+      expect(Status.needsClientTrust.needsFactor);
       expect(Status.active.needsFactor, false);
       expect(Status.verified.needsFactor, false);
     });
@@ -80,6 +84,13 @@ void main() {
       expect(Status.needsSecondFactor.needsFactorFor(Stage.first), false);
       expect(Status.active.needsFactorFor(Stage.first), false);
       expect(Status.active.needsFactorFor(Stage.second), false);
+    });
+
+    test('needsClientTrust is included in needsFactor', () {
+      expect(Status.needsClientTrust.needsFactor);
+      expect(Status.needsClientTrust, Status(name: 'needs_client_trust'));
+      expect(Status.needsClientTrust.toString(), 'needs_client_trust');
+      expect(Status.needsClientTrust.title, 'needs client trust');
     });
 
     test('toString returns the name', () {
@@ -103,7 +114,7 @@ void main() {
       expect(values.contains(Status.active));
       expect(values.contains(Status.verified));
       expect(values.contains(Status.unknown));
-      expect(values.length >= 14); // At least the predefined ones
+      expect(values.length >= 15); // At least the predefined ones
     });
 
     test('index returns correct position in values list', () {

--- a/packages/clerk_flutter/l10n/en.arb
+++ b/packages/clerk_flutter/l10n/en.arb
@@ -355,6 +355,8 @@
   "verificationPhoneNumber": "Phone number verification",
   "verified": "verified",
   "verifiedDomains": "Verified domains",
+  "verifyThisDevice": "Verify this device",
+  "@verifyThisDevice": {},
   "verifyYourEmailAddress": "Verify your email address",
   "verifyYourPhoneNumber": "Verify your phone number",
   "viaAutomaticInvitation": "via automatic invitation",

--- a/packages/clerk_flutter/lib/generated/clerk_sdk_localizations.dart
+++ b/packages/clerk_flutter/lib/generated/clerk_sdk_localizations.dart
@@ -1032,6 +1032,12 @@ abstract class ClerkSdkLocalizations {
   /// **'Verified domains'**
   String get verifiedDomains;
 
+  /// No description provided for @verifyThisDevice.
+  ///
+  /// In en, this message translates to:
+  /// **'Verify this device'**
+  String get verifyThisDevice;
+
   /// No description provided for @verifyYourEmailAddress.
   ///
   /// In en, this message translates to:

--- a/packages/clerk_flutter/lib/generated/clerk_sdk_localizations_en.dart
+++ b/packages/clerk_flutter/lib/generated/clerk_sdk_localizations_en.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: public_member_api_docs, use_super_parameters
 
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
 import 'clerk_sdk_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -546,6 +548,9 @@ class ClerkSdkLocalizationsEn extends ClerkSdkLocalizations {
 
   @override
   String get verifiedDomains => 'Verified domains';
+
+  @override
+  String get verifyThisDevice => 'Verify this device';
 
   @override
   String get verifyYourEmailAddress => 'Verify your email address';

--- a/packages/clerk_flutter/lib/src/widgets/authentication/clerk_sign_in_panel.dart
+++ b/packages/clerk_flutter/lib/src/widgets/authentication/clerk_sign_in_panel.dart
@@ -205,12 +205,17 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
     final showSecondFactors = signIn.needsSecondFactor &&
         _externalActionFactorChosen(secondFactors) == false;
 
+    final clientTrustFactors = signIn.factorsFor(clerk.Stage.second);
+    final showClientTrustFactors = signIn.needsClientTrust &&
+        _externalActionFactorChosen(clientTrustFactors) == false;
+
     final showSomething = showIdentifierInput ||
         showHeading ||
         showEmailLinkMessage ||
         showCodeInput ||
         showFirstFactors ||
-        showSecondFactors;
+        showSecondFactors ||
+        showClientTrustFactors;
 
     if (showSomething == false && signIn.hasVerification == false) {
       // If we get here, there is no way to progress. Reset.
@@ -237,12 +242,17 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
         Openable(
           key: const Key('heading'),
           open: showHeading,
-          builder: (context) => Text(
-            signIn.needsSecondFactor
-                ? l10ns.twoStepVerification
-                : _identifier.identifier,
-            style: themeExtension.styles.heading,
-          ),
+          builder: (context) {
+            late String headingText;
+            if (signIn.needsSecondFactor) {
+              headingText = l10ns.twoStepVerification;
+            } else if (signIn.needsClientTrust) {
+              headingText = l10ns.verifyThisDevice;
+            } else {
+              headingText = _identifier.identifier;
+            }
+            return Text(headingText, style: themeExtension.styles.heading);
+          },
         ),
 
         verticalMargin8,
@@ -286,6 +296,17 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
           child: _FactorList(
             key: const Key('secondFactors'),
             factors: secondFactors,
+            onPasswordChanged: _updatePassword,
+            onSubmit: (strategy) => _continue(authState, strategy: strategy),
+          ),
+        ),
+
+        // Factors for device-trust stage
+        Openable(
+          open: showClientTrustFactors,
+          child: _FactorList(
+            key: const Key('clientTrustFactors'),
+            factors: clientTrustFactors,
             onPasswordChanged: _updatePassword,
             onSubmit: (strategy) => _continue(authState, strategy: strategy),
           ),

--- a/packages/clerk_flutter/pubspec.yaml
+++ b/packages/clerk_flutter/pubspec.yaml
@@ -37,5 +37,6 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
+  generate: true
   assets:
     - assets/

--- a/packages/clerk_flutter/test/unit/widgets/authentication/clerk_sign_in_panel_test.dart
+++ b/packages/clerk_flutter/test/unit/widgets/authentication/clerk_sign_in_panel_test.dart
@@ -280,6 +280,55 @@ void main() {
         authStateWithSignIn.terminate();
       });
 
+      testWidgets('renders factor list and heading for needs_client_trust',
+          (tester) async {
+        const environment = clerk.Environment(
+          config: clerk.Config(
+            identificationStrategies: [clerk.Strategy.emailAddress],
+            firstFactors: [clerk.Strategy.password],
+          ),
+        );
+        final signIn = createTestSignIn(
+          status: clerk.Status.needsClientTrust,
+          identifier: 'test@example.com',
+          supportedSecondFactors: [
+            createTestFactor(
+              strategy: clerk.Strategy.emailCode,
+              safeIdentifier: 'test@example.com',
+              emailAddressId: 'email_123',
+            ),
+          ],
+          firstFactorVerification: createTestVerification(
+            status: clerk.Status.verified,
+            strategy: clerk.Strategy.password,
+          ),
+        );
+        final client = createTestClient(signIn: signIn);
+        final authStateWithSignIn = await createTestAuthState(
+          config: TestClerkAuthConfig(
+            initialClient: client,
+            initialEnvironment: environment,
+          ),
+        );
+
+        await tester.pumpWidget(
+          TestClerkAuthWrapper(
+            authState: authStateWithSignIn,
+            child: const Scaffold(
+              body: SingleChildScrollView(
+                child: ClerkSignInPanel(),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ClerkSignInPanel), findsOneWidget);
+        expect(find.text('Verify this device'), findsOneWidget);
+
+        authStateWithSignIn.terminate();
+      });
+
       testWidgets('renders with multiple first factors', (tester) async {
         final signIn = createTestSignIn(
           status: clerk.Status.needsFirstFactor,


### PR DESCRIPTION
Resolves #418 

This pull request adds support for the new `needs_client_trust` status in the Clerk authentication flow, ensuring that the sign-in process correctly handles scenarios where client trust verification is required. It updates the status handling logic, extends the relevant enums and models, and adds comprehensive test fixtures for this new flow.

**Support for new `needs_client_trust` status:**

* Added a new static constant `needsClientTrust` to the `Status` class and included it in status maps and logic checks, allowing the system to recognize and process this status. [[1]](diffhunk://#diff-1bf126242f1770f912a1baa0ae1f5e82ed4aa8d78ed617e428e36c5a230e77e5R39-R41) [[2]](diffhunk://#diff-1bf126242f1770f912a1baa0ae1f5e82ed4aa8d78ed617e428e36c5a230e77e5R71)
* Updated the `needsFactor` logic in both the `Status` and `SignIn` classes to include `needsClientTrust`, ensuring that any code checking for required authentication factors now also accounts for client trust requirements. [[1]](diffhunk://#diff-1bf126242f1770f912a1baa0ae1f5e82ed4aa8d78ed617e428e36c5a230e77e5L105-R112) [[2]](diffhunk://#diff-f86f1797b89ff0580de691a9270115c43cdc9cb766abea8bde3287da8c0d2f3fR104-R108)
* Added a `needsClientTrust` getter to the `SignIn` class for easier status checks.

**Authentication flow and stage handling:**

* Updated the sign-in flow in the `Auth` class to check for `needsFirstFactor` instead of the more generic `needsFactor`, improving accuracy when determining the next authentication step.
* Modified the `Stage` enum mapping to treat `needsClientTrust` as a second-factor stage, aligning it with the authentication process.
* Updated the `SignIn` class to return `secondFactorVerification` for the `needsClientTrust` status, ensuring the correct verification object is used.

**Test coverage:**

* Added new test fixtures (`001.json`, `002.json`, `003.json`, `004.json`) under `sign_in_with_client_trust` to simulate and validate the new client trust flow, covering environment setup, sign-in attempts, and second factor preparation. [[1]](diffhunk://#diff-f0069cf5c589fab4dfe05bdecfd4ded680ad6f838d149e22c6f72ab25dd291feR1-R19) [[2]](diffhunk://#diff-833a22ebcf84df6027aa36666f7cd4e7c23ecb55ac895d51f9e9f12d22acd7aeR1-R350) [[3]](diffhunk://#diff-7b8882e1355277a7626e6072233410e770df928e5fe6e2cb72165ce58df506d5R1-R109) [[4]](diffhunk://#diff-0988147451e192d1a6d4e25eecddee6fde36bb27f2feafd347c7aa4bb2636e6aR1-R121)