### PR TITLE
chore: added new_release automation tool

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,65 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'   # v0.0.17-beta, v1.0.0, etc.
+
+jobs:
+  # Publish in dependency order: clerk_backend_api → clerk_auth → clerk_flutter.
+  # Each job waits for the previous one via `needs:`.
+
+  publish_clerk_backend_api:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: packages/clerk_backend_api
+
+  publish_clerk_auth:
+    needs: publish_clerk_backend_api
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: packages/clerk_auth
+
+  # pub.dev may take ~2 minutes before the new clerk_auth version is resolvable
+  # as a dependency when publishing clerk_flutter.
+  wait_for_propagation:
+    name: Wait for clerk_auth to propagate on pub.dev
+    needs: publish_clerk_auth
+    runs-on: ubuntu-latest
+    steps:
+      - run: sleep 120
+
+  publish_clerk_flutter:
+    needs: wait_for_propagation
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
+      working-directory: packages/clerk_flutter
+
+  github_release:
+    name: Create GitHub Release
+    needs: publish_clerk_flutter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --notes "See individual package CHANGELOGs for details:
+          - [clerk_auth](packages/clerk_auth/CHANGELOG.md)
+          - [clerk_backend_api](packages/clerk_backend_api/CHANGELOG.md)
+          - [clerk_flutter](packages/clerk_flutter/CHANGELOG.md)"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,8 +55,8 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
           gh release create "$TAG" \
             --title "Release $TAG" \
             --notes "See individual package CHANGELOGs for details:

--- a/melos.yaml
+++ b/melos.yaml
@@ -4,6 +4,7 @@ sdkPath: .fvm/flutter_sdk
 packages:
   - packages/**
   - packages/clerk_flutter/example
+  - tools/new_release
 
 ide:
   intellij:
@@ -141,3 +142,19 @@ scripts:
     packageFilters:
       scope: "clerk_flutter_example"
       dirExists: coverage
+
+  # Release scripts — see tools/new_release/ for implementation.
+  new_release:
+    description: >
+      Bump versions, update changelogs, regenerate _version.dart, and commit.
+      Run on a release branch, e.g.:
+        melos run new_release -- patch --pre=beta   # 0.0.16-beta → 0.0.17-beta
+        melos run new_release -- minor              # 0.0.17-beta → 0.1.0
+    run: dart tools/new_release/bin/new_release.dart $@
+
+  tag:
+    description: >
+      Create per-package and global annotated tags, then push.
+      Run on main AFTER the release PR is merged:
+        git checkout main && git pull && melos run tag
+    run: dart tools/new_release/bin/tag.dart

--- a/tools/new_release/README.md
+++ b/tools/new_release/README.md
@@ -1,0 +1,85 @@
+# new_release
+
+Release automation tool for the Clerk Flutter SDK monorepo. Handles version bumping, changelog generation, and publishing for `clerk_auth`, `clerk_backend_api`, and `clerk_flutter` in a single command.
+
+## End-to-end flow
+
+```
+# ── On a release branch ──────────────────────────────────────────────────
+
+# Bump patch, keep the -beta suffix
+melos run new_release -- patch --pre=beta   # 0.0.16-beta → 0.0.17-beta
+
+# Or graduate to a stable release (drop beta, bump minor)
+melos run new_release -- minor              # 0.0.17-beta → 0.1.0
+
+# Review the generated diff, then open a PR
+git diff HEAD~1
+git push origin release/0.0.17-beta
+
+# ── On main, after the PR is merged ──────────────────────────────────────
+
+git checkout main && git pull
+melos run tag   # creates 4 tags and pushes → triggers pub.dev publish workflow
+```
+
+## Scripts
+
+### `melos run new_release -- <bump-type> [--pre=<id>]`
+
+Runs `bin/new_release.dart`. For each managed package it:
+
+1. Bumps `version:` in `pubspec.yaml` using the semver rule below
+2. Syncs `pubVersion` in `openapi_generator/openapi-generator-config.json`
+3. Regenerates `packages/clerk_auth/lib/src/_version.dart` via `build_runner`
+4. Prepends a new `## <version>` section to `CHANGELOG.md` from `git log` since the last per-package tag
+5. Stages all modified files and commits `chore: release v<version>`
+
+**Bump types:**
+
+| Command | Example result |
+|---|---|
+| `patch --pre=beta` | `0.0.16-beta → 0.0.17-beta` |
+| `patch` | `0.0.17-beta → 0.0.18` |
+| `minor` | `0.0.17-beta → 0.1.0` |
+| `major` | `0.0.17-beta → 1.0.0` |
+
+The `--pre` flag appends a pre-release suffix after the bump. Omitting it graduates the release to stable.
+
+### `melos run tag`
+
+Runs `bin/tag.dart`. Must be executed on `main` after the release PR is merged — running it on a feature/release branch risks creating tags that point to orphaned commits after a squash-merge.
+
+Creates four annotated tags on `HEAD` and pushes them all:
+
+```
+clerk_auth-v0.0.17-beta
+clerk_backend_api-v0.0.17-beta
+clerk_flutter-v0.0.17-beta
+v0.0.17-beta          ← global tag, triggers the pub.dev publish workflow
+```
+
+## GitHub Actions publish workflow
+
+`.github/workflows/publish.yaml` triggers on any `v*` tag push. It publishes packages to pub.dev in dependency order (`clerk_backend_api` → `clerk_auth` → `clerk_flutter`) and creates a GitHub Release. A 120-second wait is inserted between `clerk_auth` and `clerk_flutter` to allow pub.dev to propagate the newly published version.
+
+The workflow uses OIDC-based publishing — no stored pub.dev credentials are required. Two things must be configured once:
+
+| What | How |
+|---|---|
+| **pub.dev trusted publisher** | In the pub.dev package admin page, add a GitHub Actions trusted publisher pointing at this repo with environment `pub.dev` |
+| **GitHub Actions environment** | In the repo Settings → Environments, create an environment named `pub.dev` (optionally add required reviewers for extra protection) |
+| `GITHUB_TOKEN` | Automatically provided by GitHub Actions — no setup required |
+
+## Changelog format
+
+Entries follow the Melos bold-label convention:
+
+```
+## 0.0.17-beta
+
+ - **FEAT**(clerk_auth): add passkey improvements (#420).
+ - **FIX**(clerk_auth): handle offline token refresh (#421).
+```
+
+Commits that follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.) are mapped to bold labels. Other commits are included as plain bullets. Only commits that touch each package's directory are included in that package's changelog.

--- a/tools/new_release/analysis_options.yaml
+++ b/tools/new_release/analysis_options.yaml
@@ -1,0 +1,28 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+   exclude:
+     - lib/generated/**
+
+formatter:
+  page_width: 80
+
+linter:
+  rules:
+    - avoid_print
+    - avoid_unnecessary_containers
+    - avoid_web_libraries_in_flutter
+    - curly_braces_in_flow_control_structures
+    - no_logic_in_create_state
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    - public_member_api_docs
+    - sized_box_for_whitespace
+    - sort_child_properties_last
+    - sort_constructors_first
+    - unawaited_futures
+    - use_build_context_synchronously
+    - use_full_hex_values_for_flutter_colors
+    - use_key_in_widget_constructors

--- a/tools/new_release/bin/new_release.dart
+++ b/tools/new_release/bin/new_release.dart
@@ -1,0 +1,251 @@
+import 'dart:convert';
+import 'dart:io';
+
+// Publish order: least-dependent first.
+const _packages = ['clerk_backend_api', 'clerk_auth', 'clerk_flutter'];
+const _packagePaths = {
+  'clerk_backend_api': 'packages/clerk_backend_api',
+  'clerk_auth': 'packages/clerk_auth',
+  'clerk_flutter': 'packages/clerk_flutter',
+};
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty || args.contains('--help') || args.contains('-h')) {
+    _usage();
+    exit(args.isEmpty ? 1 : 0);
+  }
+
+  final bumpType = args[0];
+  if (!{'patch', 'minor', 'major'}.contains(bumpType)) {
+    stderr.writeln('Error: unknown bump type "$bumpType"');
+    _usage();
+    exit(1);
+  }
+
+  String? preId;
+  for (int i = 1; i < args.length; i++) {
+    if (args[i].startsWith('--pre=')) {
+      preId = args[i].substring('--pre='.length);
+    } else if (args[i] == '--pre' && i + 1 < args.length) {
+      preId = args[++i];
+    }
+  }
+
+  final root = Directory.current.path;
+
+  print('--- Bumping versions '
+      '($bumpType${preId != null ? ' --pre=$preId' : ''}) ---');
+
+  // 1. Update pubspec.yaml for all packages.
+  String? newVersion;
+  for (final pkg in _packages) {
+    final file = File('$root/${_packagePaths[pkg]!}/pubspec.yaml');
+    final content = await file.readAsString();
+    final current = _extractVersion(content);
+    final bumped = _bumpVersion(current, bumpType, preId);
+    newVersion ??= bumped;
+
+    await file.writeAsString(
+      content.replaceFirst(
+        RegExp(r'^version: .+$', multiLine: true),
+        'version: $bumped',
+      ),
+    );
+    print('  $pkg: $current → $bumped');
+  }
+
+  // 2. Sync pubVersion in openapi-generator-config.json.
+  final openapiConfig =
+      File('$root/openapi_generator/openapi-generator-config.json');
+  if (openapiConfig.existsSync()) {
+    final json =
+        jsonDecode(await openapiConfig.readAsString()) as Map<String, dynamic>;
+    json['pubVersion'] = newVersion;
+    await openapiConfig.writeAsString(
+        const JsonEncoder.withIndent('    ').convert(json) + '\n');
+    print('  openapi_generator/openapi-generator-config.json');
+  }
+
+  // 3. Regenerate _version.dart via build_runner.
+  print('\n--- Running build_runner for clerk_auth ---');
+  final buildResult = await Process.run(
+    'dart',
+    ['run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+    workingDirectory: '$root/packages/clerk_auth',
+  );
+  if (buildResult.exitCode != 0) {
+    stderr.writeln('build_runner failed:\n${buildResult.stderr}');
+    exit(1);
+  }
+  print('  packages/clerk_auth/lib/src/_version.dart regenerated');
+
+  // 4. Prepend changelog entries for each package.
+  print('\n--- Generating changelogs ---');
+  for (final pkg in _packages) {
+    await _generateChangelog(root, pkg, _packagePaths[pkg]!, newVersion!);
+  }
+
+  // 5. Stage specific files and commit.
+  print('\n--- Committing ---');
+  await _commit(root, newVersion!);
+
+  print('\nDone! Created commit: chore: release v$newVersion');
+  print('Next: push branch, open PR, merge to main, then run:');
+  print('  git checkout main && git pull && melos run tag');
+}
+
+void _usage() {
+  print('Usage: dart tools/new_release/bin/new_release.dart <patch|minor|major>'
+      ' [--pre=<id>]');
+  print('');
+  print('Examples:');
+  print('  patch --pre=beta   # 0.0.16-beta → 0.0.17-beta');
+  print('  minor              # 0.0.17-beta → 0.1.0');
+}
+
+String _extractVersion(String pubspec) {
+  final m = RegExp(r'^version:\s*(.+)$', multiLine: true).firstMatch(pubspec);
+  if (m == null) throw Exception('No version field found in pubspec.yaml');
+  return m.group(1)!.trim();
+}
+
+// Strips the existing pre-release suffix, applies the bump, then reattaches
+// preId (if provided). This matches Cider's --pre behaviour.
+String _bumpVersion(String current, String bumpType, String? preId) {
+  final dashIdx = current.indexOf('-');
+  final base = dashIdx >= 0 ? current.substring(0, dashIdx) : current;
+  final parts = base.split('.').map(int.parse).toList();
+
+  switch (bumpType) {
+    case 'major':
+      parts[0]++;
+      parts[1] = 0;
+      parts[2] = 0;
+    case 'minor':
+      parts[1]++;
+      parts[2] = 0;
+    case 'patch':
+      parts[2]++;
+  }
+
+  final newBase = parts.join('.');
+  return preId != null ? '$newBase-$preId' : newBase;
+}
+
+Future<void> _generateChangelog(
+  String root,
+  String pkgName,
+  String pkgPath,
+  String newVersion,
+) async {
+  // Find the most recent per-package tag to use as the git log base.
+  final tagResult = await Process.run(
+    'git',
+    ['tag', '--list', '$pkgName-v*', '--sort=-version:refname'],
+    workingDirectory: root,
+  );
+  final tags = (tagResult.stdout as String)
+      .split('\n')
+      .map((t) => t.trim())
+      .where((t) => t.isNotEmpty)
+      .toList();
+
+  final gitLogArgs = [
+    'log',
+    if (tags.isNotEmpty) '${tags.first}..HEAD',
+    '--oneline',
+    '--no-merges',
+    '--',
+    pkgPath,
+  ];
+
+  final logResult =
+      await Process.run('git', gitLogArgs, workingDirectory: root);
+  final commits = (logResult.stdout as String)
+      .split('\n')
+      .map((l) => l.trim())
+      .where((l) => l.isNotEmpty)
+      .toList();
+
+  if (commits.isEmpty) {
+    print('  $pkgName: no new commits — CHANGELOG unchanged');
+    return;
+  }
+
+  final entries = commits.map((line) {
+    final msg = line.replaceFirst(RegExp(r'^[0-9a-f]{6,}\s+'), '');
+    return _formatEntry(msg, pkgName);
+  }).toList();
+
+  final changelogFile = File('$root/$pkgPath/CHANGELOG.md');
+  final existing =
+      changelogFile.existsSync() ? await changelogFile.readAsString() : '';
+
+  final section =
+      '## $newVersion\n\n${entries.map((e) => ' - $e').join('\n')}\n\n';
+  await changelogFile.writeAsString(section + existing);
+  print(
+      '  $pkgName: ${entries.length} entr${entries.length == 1 ? 'y' : 'ies'}');
+}
+
+// Converts a commit message to the Melos-style bold-label format:
+//   fix(clerk_auth): fix something (#42) → **FIX**(clerk_auth): fix something (#42).
+String _formatEntry(String message, String pkgName) {
+  final re = RegExp(
+    r'^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)'
+    r'(\(([^)]+)\))?!?:\s*(.+)$',
+  );
+  final m = re.firstMatch(message);
+  if (m == null) return message;
+
+  final type = m.group(1)!.toUpperCase();
+  final scope = m.group(3) ?? pkgName;
+  var desc = m.group(4)!;
+
+  // Normalise bare #NNN → (#NNN).
+  final bareRef = RegExp(r'\s*#(\d+)$');
+  final parenRef = RegExp(r'\s*\(#\d+\)$');
+  if (!parenRef.hasMatch(desc)) {
+    final bare = bareRef.firstMatch(desc);
+    if (bare != null) {
+      desc = '${desc.substring(0, bare.start)} (#${bare.group(1)})';
+    }
+  }
+
+  if (!desc.endsWith('.')) desc = '$desc.';
+  return '**$type**($scope): $desc';
+}
+
+Future<void> _commit(String root, String version) async {
+  final filesToStage = [
+    'packages/clerk_auth/pubspec.yaml',
+    'packages/clerk_auth/CHANGELOG.md',
+    'packages/clerk_auth/lib/src/_version.dart',
+    'packages/clerk_backend_api/pubspec.yaml',
+    'packages/clerk_backend_api/CHANGELOG.md',
+    'packages/clerk_flutter/pubspec.yaml',
+    'packages/clerk_flutter/CHANGELOG.md',
+    'openapi_generator/openapi-generator-config.json',
+  ];
+
+  final addResult = await Process.run(
+    'git',
+    ['add', ...filesToStage],
+    workingDirectory: root,
+  );
+  if (addResult.exitCode != 0) {
+    stderr.writeln('git add failed:\n${addResult.stderr}');
+    exit(1);
+  }
+
+  final commitResult = await Process.run(
+    'git',
+    ['commit', '-m', 'chore: release v$version'],
+    workingDirectory: root,
+  );
+  if (commitResult.exitCode != 0) {
+    stderr.writeln('git commit failed:\n${commitResult.stderr}');
+    exit(1);
+  }
+  print('  chore: release v$version');
+}

--- a/tools/new_release/bin/tag.dart
+++ b/tools/new_release/bin/tag.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+const _packages = ['clerk_auth', 'clerk_backend_api', 'clerk_flutter'];
+const _packagePaths = {
+  'clerk_auth': 'packages/clerk_auth',
+  'clerk_backend_api': 'packages/clerk_backend_api',
+  'clerk_flutter': 'packages/clerk_flutter',
+};
+
+Future<void> main(List<String> args) async {
+  final root = Directory.current.path;
+
+  // Guard: must be on main to avoid orphaned tags after a squash-merge.
+  final branchResult = await Process.run(
+    'git',
+    ['branch', '--show-current'],
+    workingDirectory: root,
+  );
+  final branch = (branchResult.stdout as String).trim();
+  if (branch != 'main') {
+    stderr.writeln(
+      'ERROR: melos run tag must be run on main (currently on "$branch").\n'
+      'Merge the release PR first:\n'
+      '  git checkout main && git pull && melos run tag',
+    );
+    exit(1);
+  }
+
+  // Read current version from each pubspec.yaml and verify they all match.
+  final versions = <String, String>{};
+  for (final pkg in _packages) {
+    final file = File('$root/${_packagePaths[pkg]!}/pubspec.yaml');
+    final content = await file.readAsString();
+    final m = RegExp(r'^version:\s*(.+)$', multiLine: true).firstMatch(content);
+    versions[pkg] = m!.group(1)!.trim();
+  }
+
+  final unique = versions.values.toSet();
+  if (unique.length != 1) {
+    stderr.writeln('ERROR: packages have mismatched versions:');
+    versions.forEach((k, v) => stderr.writeln('  $k: $v'));
+    exit(1);
+  }
+  final version = unique.first;
+
+  print('Tagging release v$version...');
+
+  for (final pkg in _packages) {
+    await _tag('$pkg-v$version', 'Release $pkg $version', root);
+  }
+  await _tag('v$version', 'Release v$version', root);
+
+  print('\nPushing tags...');
+  final pushResult = await Process.run(
+    'git',
+    ['push', 'origin', '--tags'],
+    workingDirectory: root,
+  );
+  if (pushResult.exitCode != 0) {
+    stderr.writeln('git push --tags failed:\n${pushResult.stderr}');
+    exit(1);
+  }
+
+  print('\nDone! Tags pushed — pub.dev publish workflow will start shortly.');
+  for (final pkg in _packages) {
+    print('  $pkg-v$version');
+  }
+  print('  v$version  ← global trigger');
+}
+
+Future<void> _tag(String name, String message, String root) async {
+  final result = await Process.run(
+    'git',
+    ['tag', '-a', name, '-m', message],
+    workingDirectory: root,
+  );
+  if (result.exitCode != 0) {
+    stderr.writeln('Failed to create tag $name:\n${result.stderr}');
+    exit(1);
+  }
+  print('  $name');
+}

--- a/tools/new_release/pubspec.yaml
+++ b/tools/new_release/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: '>=3.6.2 <4.0.0'
 
 dev_dependencies:
-  lints: ^6.1.0
+  lints: ^5.1.1

--- a/tools/new_release/pubspec.yaml
+++ b/tools/new_release/pubspec.yaml
@@ -1,0 +1,10 @@
+name: new_release
+description: Release automation tool for the Clerk Flutter SDK monorepo.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=3.6.2 <4.0.0'
+
+dev_dependencies:
+  lints: ^6.1.0


### PR DESCRIPTION
Resolves #400 

This pull request introduces a comprehensive release automation system for the Clerk Flutter SDK monorepo. It adds a new tool and workflow to automate version bumping, changelog generation, tagging, and publishing packages to pub.dev via GitHub Actions. The changes improve the release process by making it more reliable, repeatable, and easier to execute with a single command or workflow.

Key changes include:

**Release Automation Tooling:**

* Added the `tools/new_release` package, which provides Dart scripts and documentation for automating version bumps, changelog updates, and tagging across all packages. This includes a detailed `README.md`, `analysis_options.yaml`, and `pubspec.yaml` for the tool itself. [[1]](diffhunk://#diff-bccd647490604e1e4c41bdc9317815410c9b13413d29f461a24814c7cb796923R1-R84) [[2]](diffhunk://#diff-e3cec7fd1e184ee7e703f3ec66687cb3ad0a1f8df8c18cf1ae0b61a4161315f0R1-R28) [[3]](diffhunk://#diff-95569c7feb49e08e014d981598e070e7ae08a063c372e28d850913e5b17d2409R1-R10)

**Melos Integration:**

* Updated `melos.yaml` to register the new release tool as a managed package and defined new scripts: `new_release` for preparing a release (bumping versions, updating changelogs, etc.) and `tag` for creating and pushing annotated tags. [[1]](diffhunk://#diff-cd98883b899aa4ad62ac6b5c5c3db5146fd0a5465749d4d3de63a77c525c04d3R7) [[2]](diffhunk://#diff-cd98883b899aa4ad62ac6b5c5c3db5146fd0a5465749d4d3de63a77c525c04d3R145-R160)

**Automated Publishing Workflow:**

* Added a new GitHub Actions workflow (`.github/workflows/publish.yaml`) that triggers on global tag pushes, publishes all packages to pub.dev in dependency order, waits for dependency propagation, and creates a GitHub Release with links to each package's changelog.

These changes collectively streamline and automate the release and publishing process for the monorepo, reducing manual effort and minimizing the risk of errors.