### PR TITLE
fix(actions): check pr author before assigning reviewers

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -27,13 +27,9 @@ jobs:
               assignees: ['MarkOSullivan94']
             });
 
-            // Always request slightfoot as a reviewer
-            const reviewers = ['slightfoot'];
-
-            // If PR author isn't MarkOSullivan94, also request MarkOSullivan94
-            if (pr.user.login !== 'MarkOSullivan94') {
-              reviewers.push('MarkOSullivan94');
-            }
+            // Request all maintainers to review unless one of them is the author
+            const reviewers = ['slightfoot', 'MarkOSullivan94']
+              .filter(reviewer => reviewer !== pr.user.login);
 
             await github.rest.pulls.requestReviewers({
               owner,


### PR DESCRIPTION
Resolves #422 

This pull request simplifies the logic for assigning reviewers in the `auto-assign-pr.yml` workflow. The new implementation ensures that neither the PR author nor duplicate reviewers are requested.

Reviewer assignment logic:

* Simplified the construction of the `reviewers` array by filtering out the PR author's login from the list of default reviewers (`slightfoot` and `MarkOSullivan94`), ensuring the author is not requested as a reviewer and reducing code complexity.