### PR TITLE
fix: saml enterprise sso sign in

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -361,9 +361,14 @@ class Auth {
     required Uri? redirect,
   }) async {
     final redirectUrl = redirect?.toString() ?? ClerkConstants.oauthRedirect;
-    final identifier = strategy.isEnterpriseSSO ? client.signIn?.identifier : null;
+    final identifier =
+        strategy.isEnterpriseSSO ? client.signIn?.identifier : null;
     await _api
-        .createSignIn(strategy: strategy, redirectUrl: redirectUrl, identifier: identifier)
+        .createSignIn(
+          strategy: strategy,
+          redirectUrl: redirectUrl,
+          identifier: identifier,
+        )
         .then(_housekeeping);
     if (client.signIn case SignIn signIn when signIn.hasVerification == false) {
       await _catchExternalErrors(

--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -361,8 +361,9 @@ class Auth {
     required Uri? redirect,
   }) async {
     final redirectUrl = redirect?.toString() ?? ClerkConstants.oauthRedirect;
+    final identifier = strategy.isEnterpriseSSO ? client.signIn?.identifier : null;
     await _api
-        .createSignIn(strategy: strategy, redirectUrl: redirectUrl)
+        .createSignIn(strategy: strategy, redirectUrl: redirectUrl, identifier: identifier)
         .then(_housekeeping);
     if (client.signIn case SignIn signIn when signIn.hasVerification == false) {
       await _catchExternalErrors(

--- a/packages/clerk_auth/lib/src/models/client/strategy.dart
+++ b/packages/clerk_auth/lib/src/models/client/strategy.dart
@@ -269,7 +269,7 @@ class Strategy {
   bool get isEnterpriseSSO => this == enterpriseSSO;
 
   /// is SSO?
-  bool get isSSO => name == _oauth || isEnterpriseSSO;
+  bool get isSSO => name == _oauth || isEnterpriseSSO || this == saml;
 
   /// requires redirect?
   bool get requiresRedirect =>

--- a/packages/clerk_auth/test/unit/models/strategy_test.dart
+++ b/packages/clerk_auth/test/unit/models/strategy_test.dart
@@ -159,6 +159,9 @@ void main() {
         expect(Strategy.oauthGoogle.isSSO);
         expect(Strategy.enterpriseSSO.isSSO);
         expect(Strategy.password.isSSO, false);
+        // Bug 421: saml is returned by the server after enterprise_sso round-trip
+        // and must be treated as SSO so parseDeepLink completes sign-in.
+        expect(Strategy.saml.isSSO, isTrue);
       });
     });
 

--- a/packages/clerk_flutter/example/patrol_test/sign_in_with_google_test.dart
+++ b/packages/clerk_flutter/example/patrol_test/sign_in_with_google_test.dart
@@ -24,7 +24,6 @@ import 'sign_in_with_google_common.dart';
 void main() {
   const googleEmail = String.fromEnvironment('GOOGLE_EMAIL');
 
-
   patrolTest(
     'Sign in with Google & sign out',
     platformAutomatorConfig: PlatformAutomatorConfig.fromOptions(
@@ -72,7 +71,8 @@ void main() {
 
       await signOut($);
 
-      await $(googleSocialButtonSelector).waitUntilVisible(timeout: const Duration(seconds: 5));
+      await $(googleSocialButtonSelector)
+          .waitUntilVisible(timeout: const Duration(seconds: 5));
 
       expect(googleSocialButtonSelector, findsOneWidget);
     },

--- a/packages/clerk_flutter/lib/src/widgets/authentication/clerk_sign_in_panel.dart
+++ b/packages/clerk_flutter/lib/src/widgets/authentication/clerk_sign_in_panel.dart
@@ -87,6 +87,8 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
           ? authState.emailVerificationRedirectUri(context)
           : null;
 
+      bool needsEnterpriseSSO = false;
+
       await authState.safelyCall(
         context,
         () async {
@@ -123,10 +125,7 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
             } else if (signIn.factors case final factors
                 when factors.isNotEmpty) {
               if (factors.any((f) => f.strategy.isEnterpriseSSO)) {
-                await authState.ssoSignIn(
-                  context,
-                  clerk.Strategy.enterpriseSSO,
-                );
+                needsEnterpriseSSO = true;
               } else if (signIn.needsFactor && factors.length == 1) {
                 await authState.attemptSignIn(strategy: factors.first.strategy);
               }
@@ -139,6 +138,14 @@ class _ClerkSignInPanelState extends State<ClerkSignInPanel>
         },
         onError: _onError,
       );
+
+      if (needsEnterpriseSSO && mounted) {
+        await authState.ssoSignIn(
+          context,
+          clerk.Strategy.enterpriseSSO,
+          onError: _onError,
+        );
+      }
     }
   }
 

--- a/packages/clerk_flutter/test/unit/clerk_auth_state_test.dart
+++ b/packages/clerk_flutter/test/unit/clerk_auth_state_test.dart
@@ -391,7 +391,8 @@ void main() {
     });
 
     group('refreshClient race condition', () {
-      test('stale refreshClient() response overwrites signed-in client', () async {
+      test('stale refreshClient() response overwrites signed-in client',
+          () async {
         final now = DateTime.now();
         final signedInClient = createSignedInClient();
         final staleClient = clerk.Client(
@@ -434,7 +435,8 @@ void main() {
           final staleClient = clerk.Client(
             id: 'client_stale',
             sessions: const [],
-            updatedAt: signedInClient.updatedAt, // same timestamp — `<` does not block
+            updatedAt:
+                signedInClient.updatedAt, // same timestamp — `<` does not block
             createdAt: signedInClient.createdAt,
           );
 
@@ -500,7 +502,8 @@ void main() {
                   lockStarted = true;
                   // Start safelyCall — acquires the lock and suspends at the
                   // completer, keeping the lock held for the rest of the test.
-                  authState.safelyCall(context, () => safelyCallCompleter.future);
+                  authState.safelyCall(
+                      context, () => safelyCallCompleter.future);
                 }
                 return const SizedBox();
               }),
@@ -666,6 +669,127 @@ void main() {
       });
     });
   });
+// Bug 421 — Bug 1: oauthSignIn must forward identifier for enterprise_sso
+  group('oauthSignIn identifier forwarding', () {
+    test(
+      'passes identifier from existing signIn to createSignIn for enterprise_sso',
+      () async {
+        final signIn = createTestSignIn(
+          identifier: 'user@saml-domain.com',
+          status: clerk.Status.needsFirstFactor,
+          // Provide a verification so hasVerification==true and oauthSignIn
+          // skips the prepareSignIn call (which would fail for enterpriseSSO).
+          firstFactorVerification: createTestVerification(
+            strategy: clerk.Strategy.enterpriseSSO,
+            status: clerk.Status.unverified,
+          ),
+        );
+        final client = createTestClient(signIn: signIn);
+        final capturingService = _CapturingHttpService(client: client);
+        final authState = await ClerkAuthState.create(
+          config: TestClerkAuthConfig(httpService: capturingService),
+        );
+
+        await authState.oauthSignIn(
+          strategy: clerk.Strategy.enterpriseSSO,
+          redirect: null,
+        );
+
+        final createSignInCall = capturingService.capturedRequests
+            .where((r) =>
+                r.uri.path.contains('/sign_ins') &&
+                r.method == clerk.HttpMethod.post)
+            .firstOrNull;
+        expect(
+          createSignInCall,
+          isNotNull,
+          reason: 'Expected a POST to /sign_ins',
+        );
+        expect(
+          createSignInCall!.params?['identifier'],
+          'user@saml-domain.com',
+          reason:
+              'enterprise_sso createSignIn must include the identifier so the server can resolve the SAML connection',
+        );
+
+        authState.terminate();
+      },
+    );
+  });
+
+  // Bug 421 — Bug 2: parseDeepLink must complete sign-in when verification strategy is saml
+  group('parseDeepLink saml strategy', () {
+    test(
+      'calls completeOAuthSignIn when firstFactorVerification strategy is saml',
+      () async {
+        final signIn = createTestSignIn(
+          status: clerk.Status.needsFirstFactor,
+          firstFactorVerification: createTestVerification(
+            strategy: clerk.Strategy.saml,
+            status: clerk.Status.unverified,
+          ),
+        );
+        final client = createTestClient(signIn: signIn);
+        final capturingService = _CapturingHttpService(client: client);
+        final authState = await ClerkAuthState.create(
+          config: TestClerkAuthConfig(httpService: capturingService),
+        );
+
+        final uri = Uri.parse(
+          'com.clerk.flutter://callback?rotating_token_nonce=nonce_abc123',
+        );
+        await authState.parseDeepLink(uri);
+
+        final oauthCompletionCall = capturingService.capturedRequests
+            .where((r) =>
+                r.uri.path.contains('/sign_ins/') &&
+                r.method == clerk.HttpMethod.get &&
+                r.uri.queryParameters['rotating_token_nonce'] == 'nonce_abc123')
+            .firstOrNull;
+        expect(
+          oauthCompletionCall,
+          isNotNull,
+          reason:
+              'parseDeepLink must call completeOAuthSignIn (GET /sign_ins/{id}?rotating_token_nonce=...) '
+              'when the verification strategy is saml',
+        );
+
+        authState.terminate();
+      },
+    );
+  });
+}
+
+class _CapturedRequest {
+  _CapturedRequest(this.method, this.uri, this.params);
+
+  final clerk.HttpMethod method;
+  final Uri uri;
+  final Map<String, dynamic>? params;
+}
+
+class _CapturingHttpService extends TestHttpService {
+  _CapturingHttpService({super.client});
+
+  final List<_CapturedRequest> capturedRequests = [];
+
+  @override
+  Future<Response> send(
+    clerk.HttpMethod method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Map<String, dynamic>? params,
+    String? body,
+  }) {
+    capturedRequests.add(_CapturedRequest(method, uri, params));
+    return super.send(
+      method,
+      uri,
+      headers: headers,
+      params: params,
+      body: body,
+    );
+  }
 }
 
 class _StaleRefreshHttpService extends TestHttpService {
@@ -695,7 +819,8 @@ class _StaleRefreshHttpService extends TestHttpService {
       }
       _initialized = true;
     }
-    return super.send(method, uri, headers: headers, params: params, body: body);
+    return super
+        .send(method, uri, headers: headers, params: params, body: body);
   }
 }
 
@@ -724,6 +849,7 @@ class _SsoErrorHttpService extends TestHttpService {
         422,
       ));
     }
-    return super.send(method, uri, headers: headers, params: params, body: body);
+    return super
+        .send(method, uri, headers: headers, params: params, body: body);
   }
 }

--- a/tools/new_release/bin/tag.dart
+++ b/tools/new_release/bin/tag.dart
@@ -61,7 +61,8 @@ Future<void> main(List<String> args) async {
     exit(1);
   }
 
-  stdout.writeln('\nDone! Tags pushed — pub.dev publish workflow will start shortly.');
+  stdout.writeln(
+      '\nDone! Tags pushed — pub.dev publish workflow will start shortly.');
   for (final pkg in _packages) {
     stdout.writeln('  $pkg-v$version');
   }


### PR DESCRIPTION
Resolves #421 

This pull request addresses two bugs related to SSO and SAML authentication flows, ensuring correct handling of the `identifier` for enterprise SSO sign-ins and proper SSO detection for SAML strategies. It adds new tests to verify these behaviors and refactors the sign-in panel logic to improve handling of enterprise SSO factors.

**Bug fixes and authentication logic improvements:**

* The `oauthSignIn` method now forwards the `identifier` from the existing `SignIn` object when using the `enterprise_sso` strategy, ensuring the server can resolve the correct SAML connection.
* The `isSSO` getter in the `Strategy` class now treats the `saml` strategy as SSO, fixing issues where SAML-based sign-ins were not recognized as SSO.

**Sign-in panel logic refactor:**

* The sign-in panel now sets a flag (`needsEnterpriseSSO`) if enterprise SSO is required, and calls `ssoSignIn` after the main sign-in attempt, improving control flow and error handling. [[1]](diffhunk://#diff-b254b365d23eafd8a78cead7e510966eed2df6b2565cac2119511d08c8321c74R90-R91) [[2]](diffhunk://#diff-b254b365d23eafd8a78cead7e510966eed2df6b2565cac2119511d08c8321c74L126-R128) [[3]](diffhunk://#diff-b254b365d23eafd8a78cead7e510966eed2df6b2565cac2119511d08c8321c74R141-R148)

**Testing and coverage:**

* Adds unit tests to verify that `oauthSignIn` correctly forwards the `identifier` for enterprise SSO, and that `parseDeepLink` completes sign-in when the verification strategy is SAML. Supporting test utilities for capturing HTTP requests are also included. [[1]](diffhunk://#diff-5c004eaf7ee89788dc57c8b7e3eb2a6ad328b8da37183d1ddd7799d4383eff35R1-R7) [[2]](diffhunk://#diff-5c004eaf7ee89788dc57c8b7e3eb2a6ad328b8da37183d1ddd7799d4383eff35R321-R437)
* Adds a unit test to ensure the `isSSO` getter returns `true` for the `saml` strategy.

**Additional thoughts**

As signing in with Okta requires interaction with a web view it would be a good idea if we could add a Patrol test for this entire flow to avoid future regressions in the future