### PR TITLE
fix(clerk_flutter): silent sign out after external browser sso

### DIFF
--- a/packages/clerk_auth/lib/src/clerk_api/api.dart
+++ b/packages/clerk_auth/lib/src/clerk_api/api.dart
@@ -116,6 +116,11 @@ class Api with Logging {
     return Environment.empty;
   }
 
+  // Number of consecutive mismatched `GET /client` responses after which
+  // the pinned client is deemed genuinely gone and the new one adopted
+  static const _maxClientMismatches = 3;
+  int _clientMismatchCount = 0;
+
   Future<Client> _fetchClient({required HttpMethod method}) async {
     final resp = await _fetch(
       path: '/client',
@@ -125,8 +130,23 @@ class Api with Logging {
     if (resp.statusCode == HttpStatus.ok) {
       final body = json.decode(resp.body) as _JsonObject;
       final client = Client.fromJson(body[_kResponseKey]);
-      _tokenCache.updateFrom(resp, client);
-      return client;
+      final accepted = _tokenCache.updateFrom(
+        resp,
+        client,
+        // POST explicitly creates a new client; a GET must return the
+        // client we are pinned to unless it is demonstrably gone
+        allowClientChange: method == HttpMethod.post ||
+            _clientMismatchCount >= _maxClientMismatches,
+      );
+      if (accepted) {
+        _clientMismatchCount = 0;
+        return client;
+      }
+      _clientMismatchCount += 1;
+      logNotice(
+        'Discarded /client response for mismatched client ${client.id} '
+        '(expecting ${_tokenCache.clientId})',
+      );
     }
     return Client.empty;
   }
@@ -1011,7 +1031,9 @@ class Api with Logging {
     final (clientData, responseData) = _extractClientAndResponse(body);
     if (clientData is _JsonObject) {
       final client = Client.fromJson(clientData);
-      _tokenCache.updateFrom(resp, client);
+      if (resp.statusCode == HttpStatus.ok) {
+        _tokenCache.updateFrom(resp, client);
+      }
       return ApiResponse(
         client: client,
         status: resp.statusCode,
@@ -1055,6 +1077,20 @@ class Api with Logging {
     return param;
   }
 
+  // The client token is a rotating credential: a response can invalidate
+  // the token presented by any request still in flight, so requests are
+  // serialised and the authorization header is stamped from the token
+  // cache at send time rather than at call time.
+  Future<http.Response> _queue = Future.value(_emptyResponse);
+
+  static final _emptyResponse = http.Response('', HttpStatus.ok);
+
+  Future<http.Response> _enqueue(Future<http.Response> Function() fn) {
+    final response = _queue.then((_) => fn());
+    _queue = response.catchError((_) => _emptyResponse);
+    return response;
+  }
+
   Future<http.Response> _fetch({
     required String path,
     HttpMethod method = HttpMethod.post,
@@ -1062,7 +1098,7 @@ class Api with Logging {
     _JsonObject? params,
     _JsonObject? nullableParams,
     bool withSession = false,
-  }) async {
+  }) {
     final bodyParams = {
       if (params?.entries case final entries?) //
         for (final MapEntry(:key, :value) in entries) //
@@ -1076,6 +1112,20 @@ class Api with Logging {
       bodyParams: bodyParams,
     );
     final uri = _uri(path, params: queryParams);
+
+    return _enqueue(() => _send(method, uri, headers, bodyParams));
+  }
+
+  Future<http.Response> _send(
+    HttpMethod method,
+    Uri uri,
+    Map<String, String>? headers,
+    _JsonObject bodyParams,
+  ) async {
+    if (headers?.containsKey(HttpHeaders.authorizationHeader) == true &&
+        _tokenCache.hasClientToken) {
+      headers![HttpHeaders.authorizationHeader] = _tokenCache.clientToken;
+    }
 
     return await config.retryOptions.retry(
       () async {

--- a/packages/clerk_auth/lib/src/clerk_api/token_cache.dart
+++ b/packages/clerk_auth/lib/src/clerk_api/token_cache.dart
@@ -148,14 +148,28 @@ class TokenCache {
   /// Update the tokens and IDs from a newly arrived [http.Response]
   /// and [Session]
   ///
-  void updateFrom(http.Response resp, Client client) {
+  /// Once a client id is cached, credentials for a different client are
+  /// discarded unless [allowClientChange] is set: a response resolving to
+  /// another client means the token presented by its request had already
+  /// been rotated away (e.g. during an oAuth handoff), and adopting the
+  /// new identity would orphan the pinned client and its sessions.
+  ///
+  /// Returns whether the credentials were accepted.
+  bool updateFrom(
+    http.Response resp,
+    Client client, {
+    bool allowClientChange = false,
+  }) {
+    if (client.id case String id when id != _clientId) {
+      if (hasClientId && allowClientChange == false) {
+        return false;
+      }
+      _setClientId(id);
+    }
+
     final newClientToken = resp.headers[HttpHeaders.authorizationHeader];
     if (newClientToken case String token) {
       _setClientToken(token);
-    }
-
-    if (client.id case String id) {
-      _setClientId(id);
     }
 
     if (client.activeSession case Session session) {
@@ -167,5 +181,7 @@ class TokenCache {
         makeAndCacheSessionToken(jwt);
       }
     }
+
+    return true;
   }
 }

--- a/packages/clerk_auth/lib/src/clerk_auth/auth.dart
+++ b/packages/clerk_auth/lib/src/clerk_auth/auth.dart
@@ -282,9 +282,16 @@ class Auth {
 
   /// Refresh the current [Client]
   ///
+  /// A refresh can only confirm or advance the client we already have:
+  /// an empty result (transient failure, or a response discarded because
+  /// it resolved to a different client) leaves the current client intact.
+  /// Only explicit operations ([signOut], [resetClient]) may clear it.
   Future<void> refreshClient() async {
-    client = await _api.currentClient();
-    update();
+    final newClient = await _api.currentClient();
+    if (newClient.isNotEmpty) {
+      client = newClient;
+      update();
+    }
   }
 
   /// Reset the current [Client]: clear any [SignUp] or [SignIn] object

--- a/packages/clerk_auth/test/unit/clerk_api/request_serialization_test.dart
+++ b/packages/clerk_auth/test/unit/clerk_api/request_serialization_test.dart
@@ -1,0 +1,82 @@
+import 'dart:math' as math;
+
+import 'package:clerk_auth/clerk_auth.dart';
+import 'package:http/http.dart' show Response;
+
+import '../../test_helpers.dart';
+
+// Valid publishable key with base64-encoded domain (somedomain.com)
+const _validPublishableKey = 'pk_test_c29tZWRvbWFpbi5jb20K';
+
+/// An [MockHttpService] that records how many requests are in flight
+/// simultaneously, so tests can assert that requests are serialised.
+class _CountingHttpService extends MockHttpService {
+  int _inFlight = 0;
+
+  /// The largest number of requests that were ever in flight at once
+  int maxInFlight = 0;
+
+  @override
+  Future<Response> send(
+    HttpMethod method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Map<String, dynamic>? params,
+    String? body,
+  }) async {
+    _inFlight += 1;
+    maxInFlight = math.max(maxInFlight, _inFlight);
+    try {
+      // hold the request open long enough for concurrent callers to overlap
+      await Future.delayed(const Duration(milliseconds: 20));
+      return await super.send(
+        method,
+        uri,
+        headers: headers,
+        params: params,
+        body: body,
+      );
+    } finally {
+      _inFlight -= 1;
+    }
+  }
+}
+
+void main() {
+  group('Api request serialisation', () {
+    // The client token is a rotating credential: concurrent requests can
+    // present a token that another response has just rotated away, which
+    // the back end answers by minting a fresh session-less client. All
+    // front-end API requests are therefore serialised.
+    test('concurrent requests are sent one at a time', () async {
+      final http = _CountingHttpService();
+      http.addClientResponse(clientId: 'client_A');
+      http.addEnvironmentResponse();
+      for (var i = 0; i < 3; i++) {
+        http.addClientResponse(clientId: 'client_A');
+      }
+
+      final auth = Auth(
+        config: TestAuthConfig(
+          publishableKey: _validPublishableKey,
+          httpService: http,
+        ),
+      );
+
+      await auth.initialize();
+      http.maxInFlight = 0;
+
+      await Future.wait([
+        auth.refreshClient(),
+        auth.refreshClient(),
+        auth.refreshClient(),
+      ]);
+
+      // requests must be serialised so that no request is sent with a
+      // token that a concurrent response can rotate away
+      expect(http.maxInFlight, 1);
+
+      auth.terminate();
+    });
+  });
+}

--- a/packages/clerk_auth/test/unit/clerk_auth/auth_test.dart
+++ b/packages/clerk_auth/test/unit/clerk_auth/auth_test.dart
@@ -500,10 +500,10 @@ void main() {
       });
 
       group('refreshClient', () {
-        test('updates client from API', () async {
+        test('updates the current client from the API', () async {
           mockHttp.addClientResponse(clientId: 'client_initial');
           mockHttp.addEnvironmentResponse();
-          mockHttp.addClientResponse(clientId: 'client_refreshed');
+          mockHttp.addClientWithSessionResponse(clientId: 'client_initial');
 
           auth = Auth(
             config: TestAuthConfig(
@@ -514,9 +514,97 @@ void main() {
 
           await auth.initialize();
           expect(auth.client.id, 'client_initial');
+          expect(auth.user, isNull);
 
           await auth.refreshClient();
-          expect(auth.client.id, 'client_refreshed');
+          expect(auth.client.id, 'client_initial');
+          expect(auth.user, isNotNull);
+
+          auth.terminate();
+        });
+
+        // Regression test: during an oAuth handoff the client token is
+        // rotated, and a refresh presenting the superseded token resolves
+        // to a freshly minted, session-less client. Adopting it silently
+        // signs the user out and orphans the real client.
+        test('discards a refresh that resolves to a different client',
+            () async {
+          mockHttp.addClientWithSessionResponse(clientId: 'client_original');
+          mockHttp.addEnvironmentResponse();
+          mockHttp.addClientResponse(clientId: 'client_minted');
+
+          auth = Auth(
+            config: TestAuthConfig(
+              publishableKey: _validPublishableKey,
+              httpService: mockHttp,
+            ),
+          );
+
+          await auth.initialize();
+          expect(auth.user, isNotNull);
+
+          await auth.refreshClient();
+
+          // a refresh resolving to a different client must not replace
+          // the signed-in client
+          expect(auth.client.id, 'client_original');
+          expect(auth.user, isNotNull);
+
+          auth.terminate();
+        });
+
+        test('adopts a persistently mismatched client after repeated refreshes',
+            () async {
+          mockHttp.addClientWithSessionResponse(clientId: 'client_original');
+          mockHttp.addEnvironmentResponse();
+          for (var i = 0; i < 4; i++) {
+            mockHttp.addClientResponse(clientId: 'client_replacement');
+          }
+
+          auth = Auth(
+            config: TestAuthConfig(
+              publishableKey: _validPublishableKey,
+              httpService: mockHttp,
+            ),
+          );
+
+          await auth.initialize();
+
+          // mismatched clients must be discarded until the pinned client
+          // is demonstrably gone
+          for (var i = 0; i < 3; i++) {
+            await auth.refreshClient();
+            expect(auth.client.id, 'client_original');
+          }
+
+          // the pinned client has not been returned for several consecutive
+          // refreshes: it is genuinely gone, so the new client is adopted
+          await auth.refreshClient();
+          expect(auth.client.id, 'client_replacement');
+
+          auth.terminate();
+        });
+
+        test('keeps the current client when the refresh fails', () async {
+          mockHttp.addClientWithSessionResponse(clientId: 'client_original');
+          mockHttp.addEnvironmentResponse();
+          mockHttp.addJsonResponse({'errors': []}, statusCode: 500);
+
+          auth = Auth(
+            config: TestAuthConfig(
+              publishableKey: _validPublishableKey,
+              httpService: mockHttp,
+            ),
+          );
+
+          await auth.initialize();
+          expect(auth.user, isNotNull);
+
+          await auth.refreshClient();
+
+          // a failed refresh must not sign the user out
+          expect(auth.client.id, 'client_original');
+          expect(auth.user, isNotNull);
 
           auth.terminate();
         });

--- a/packages/clerk_flutter/lib/src/clerk_auth_state.dart
+++ b/packages/clerk_flutter/lib/src/clerk_auth_state.dart
@@ -75,9 +75,21 @@ class ClerkAuthState extends clerk.Auth with ChangeNotifier {
     _errors.close();
   }
 
-  void _processDeepLink(Uri? link) {
+  // Holds the update lock for the duration of the parse so that
+  // timer-fired client refreshes (see the guard on [refreshClient]) cannot
+  // race the completion of an SSO flow: both would present the same client
+  // token, which the flow's completion rotates, and the refresh response
+  // could otherwise resolve to — and adopt — a freshly minted empty client.
+  Future<void> _processDeepLink(Uri? link) async {
     if (link case Uri link) {
-      parseDeepLink(link);
+      _updateLock.lock();
+      try {
+        await parseDeepLink(link);
+      } finally {
+        if (_updateLock.release()) {
+          update();
+        }
+      }
     }
   }
 

--- a/packages/clerk_flutter/test/test_support/src/test_clerk_auth_config.dart
+++ b/packages/clerk_flutter/test/test_support/src/test_clerk_auth_config.dart
@@ -13,6 +13,7 @@ class TestClerkAuthConfig extends ClerkAuthConfig {
   /// Create a test configuration with sensible defaults for testing
   TestClerkAuthConfig({
     super.publishableKey = 'pk_test_dGVzdC5jbGVyay5kZXYk',
+    super.deepLinkStream,
     TestHttpService? httpService,
     Client? initialClient,
     Environment? initialEnvironment,

--- a/packages/clerk_flutter/test/unit/clerk_auth_state_test.dart
+++ b/packages/clerk_flutter/test/unit/clerk_auth_state_test.dart
@@ -528,6 +528,130 @@ void main() {
           authState.terminate();
         },
       );
+
+      // Regression test for the oAuth handoff race: the completion of an
+      // SSO flow rotates the client token, so a refresh racing it presents
+      // a superseded token, which the back end answers with a freshly
+      // minted session-less client — different id, NEWER timestamp, so the
+      // timestamp guard alone does not block it.
+      test(
+        'refresh resolving to a freshly minted client must not sign out',
+        () async {
+          final signedInClient = createSignedInClient();
+          final mintedClient = clerk.Client(
+            id: 'client_minted',
+            sessions: const [],
+            updatedAt:
+                signedInClient.updatedAt.add(const Duration(milliseconds: 100)),
+            createdAt:
+                signedInClient.updatedAt.add(const Duration(milliseconds: 100)),
+          );
+
+          final authState = await ClerkAuthState.create(
+            config: TestClerkAuthConfig(
+              httpService: _StaleRefreshHttpService(
+                initialClient: signedInClient,
+                staleClient: mintedClient,
+              ),
+            ),
+          );
+
+          expect(authState.user, isNotNull, reason: 'should start signed in');
+
+          await authState.refreshClient();
+
+          expect(authState.client.id, signedInClient.id);
+          expect(
+            authState.user,
+            isNotNull,
+            reason: 'a refresh resolving to a different client must be '
+                'discarded, not adopted',
+          );
+
+          authState.terminate();
+        },
+      );
+
+      test('failed refresh must not sign the user out', () async {
+        final authState = await ClerkAuthState.create(
+          config: TestClerkAuthConfig(
+            httpService: _FailingRefreshHttpService(
+              initialClient: createSignedInClient(),
+            ),
+          ),
+        );
+
+        expect(authState.user, isNotNull, reason: 'should start signed in');
+
+        await authState.refreshClient();
+
+        expect(
+          authState.user,
+          isNotNull,
+          reason: 'a transient refresh failure must not sign the user out',
+        );
+
+        authState.terminate();
+      });
+    });
+
+    group('deep link handling', () {
+      // The deep-link completion of an SSO flow must hold the update lock
+      // so that timer-fired client refreshes are suppressed while the
+      // rotating token nonce exchange is in flight (see Guard 1 on
+      // refreshClient).
+      test('client refresh is suppressed while a deep link is being parsed',
+          () async {
+        final signingInClient = createTestClient(
+          signIn: createTestSignIn(
+            status: clerk.Status.needsFirstFactor,
+            firstFactorVerification: createTestVerification(
+              status: clerk.Status.unverified,
+              strategy: clerk.Strategy.oauthGoogle,
+            ),
+          ),
+        );
+
+        final httpService = _SlowSsoHttpService(initialClient: signingInClient);
+        final deepLinks = StreamController<Uri?>();
+
+        final authState = await ClerkAuthState.create(
+          config: TestClerkAuthConfig(
+            httpService: httpService,
+            deepLinkStream: deepLinks.stream,
+          ),
+        );
+
+        deepLinks.add(
+          Uri.parse('clerk://example.com/oauth?rotating_token_nonce=nonce123'),
+        );
+
+        // let the deep link reach parseDeepLink and suspend on the held
+        // sign-in response
+        await Future.delayed(const Duration(milliseconds: 20));
+        expect(httpService.signInRequested, isTrue,
+            reason: 'nonce exchange should be in flight');
+
+        httpService.clientGetCount = 0;
+        await authState.refreshClient();
+        expect(
+          httpService.clientGetCount,
+          0,
+          reason: 'refreshClient must be suppressed while the deep link '
+              'parse holds the update lock',
+        );
+
+        // complete the nonce exchange and confirm the lock is released
+        httpService.releaseSignIn();
+        await Future.delayed(const Duration(milliseconds: 20));
+
+        await authState.refreshClient();
+        expect(httpService.clientGetCount, 1,
+            reason: 'refreshClient should run once the lock is released');
+
+        await deepLinks.close();
+        authState.terminate();
+      });
     });
 
     group('ssoSignIn', () {
@@ -694,6 +818,72 @@ class _StaleRefreshHttpService extends TestHttpService {
         ));
       }
       _initialized = true;
+    }
+    return super.send(method, uri, headers: headers, params: params, body: body);
+  }
+}
+
+class _FailingRefreshHttpService extends TestHttpService {
+  _FailingRefreshHttpService({
+    required clerk.Client initialClient,
+  }) : super(client: initialClient);
+
+  bool _initialized = false;
+
+  @override
+  Future<Response> send(
+    clerk.HttpMethod method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Map<String, dynamic>? params,
+    String? body,
+  }) {
+    if (uri.path.contains('/client')) {
+      if (_initialized) {
+        return Future.value(Response(jsonEncode({'errors': []}), 500));
+      }
+      _initialized = true;
+    }
+    return super.send(method, uri, headers: headers, params: params, body: body);
+  }
+}
+
+/// Holds the response to the SSO nonce exchange open until [releaseSignIn]
+/// is called, and counts `GET /client` requests, so tests can observe what
+/// runs while a deep link is being parsed.
+class _SlowSsoHttpService extends TestHttpService {
+  _SlowSsoHttpService({
+    required clerk.Client initialClient,
+  })  : _client = initialClient,
+        super(client: initialClient);
+
+  final clerk.Client _client;
+  final _signInCompleter = Completer<void>();
+
+  bool signInRequested = false;
+  int clientGetCount = 0;
+
+  void releaseSignIn() => _signInCompleter.complete();
+
+  @override
+  Future<Response> send(
+    clerk.HttpMethod method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Map<String, dynamic>? params,
+    String? body,
+  }) async {
+    if (uri.path.contains('/client/sign_ins')) {
+      signInRequested = true;
+      await _signInCompleter.future;
+      final clientJson = _client.toJson();
+      return Response(
+        jsonEncode({'response': clientJson['sign_in'], 'client': clientJson}),
+        200,
+      );
+    }
+    if (uri.path.endsWith('/client') && method == clerk.HttpMethod.get) {
+      clientGetCount += 1;
     }
     return super.send(method, uri, headers: headers, params: params, body: body);
   }


### PR DESCRIPTION
Fixes #425 

Fixes the silent sign-out that occurs when the periodic client refresh races the `rotating_token_nonce` exchange after an external-browser OAuth flow (see the companion issue for the full diagnosis). 

The client token is a rotating credential: the completion of an SSO flow invalidates the token presented by any request still in flight, and the back end can answer such a request with a freshly minted session-less client — which the SDK then adopted, signing the user out and persisting the wrong identity.

The fix is layered: serialise requests so the race cannot form, pin the client identity so a stray response cannot re-identify the app, and contain failures so that a background refresh can never sign the user out.

## Changes

### `clerk_auth`

**`Api._fetch` — requests are serialised** (root fix)

All front-end API requests now run through a single-flight queue, and the `authorization` header is stamped from the token cache at *send* time rather than at call time. No request is ever in flight while another response can rotate the token it presents, and responses apply to the token cache in a well-defined order. FAPI traffic in this SDK is low-volume, so the lost parallelism is negligible.

**`TokenCache.updateFrom` — client-id pinning** (defence in depth)

Once a client id is cached, credentials resolving to a *different* client id are discarded (`updateFrom` now returns whether they were accepted). A response naming a different client means the request's token had already been rotated away; adopting the new identity would orphan the signed-in client. Explicit client-creating operations
pass `allowClientChange: true`.

**`Api._fetchClient` — mismatch recovery**

`POST /client` (an explicit create) may always change the pinned client. A `GET` must return the pinned client; a mismatch is discarded and counted, and only after 3 consecutive mismatches — the pinned client is demonstrably gone — is the new client adopted, so a genuinely expired/deleted client still recovers instead of wedging.

**`Auth.refreshClient` — a refresh can never sign you out** (failure containment)

An empty result (transient failure, non-200, or a discarded mismatched response) now leaves the current client intact. Only explicit operations (`signOut`,`resetClient`) clear a signed-in client. This also fixes the production-instance variant of the bug, where a stale token yields a 401 → `Client.empty` → sign-out.

**`Api._processResponse` — no credential updates from error responses**

The token cache is only updated from 200 responses.

### `clerk_flutter`

**`ClerkAuthState._processDeepLink` — holds the update lock**

The deep-link completion path now acquires the same update lock as `safelyCall`, so the existing Guard 1 on `refreshClient` suppresses timer-fired refreshes for the duration of the nonce exchange. This matches the webview SSO path, which was already protected; the external-browser deep-link path was not.

## Tests

**Kept** — the existing `refreshClient race condition` group in `clerk_auth_state_test.dart` (stale/equal-timestamp clients, Guard 1 via `safelyCall`) still covers the previous incarnation of this bug and passes unchanged.

**Replaced** — `auth_test.dart`'s `refreshClient` test asserted the old, unsafe behaviour (a refresh adopting a client with a *different id*). 

It is replaced by:

- `updates the current client from the API` — same-id refresh still applies.
- `discards a refresh that resolves to a different client` — the minted-client regression, exercising the pinning path.
- `adopts a persistently mismatched client after repeated refreshes` — the recovery path after the mismatch threshold.
- `keeps the current client when the refresh fails` — non-200 containment.

**Added**

- `request_serialization_test.dart` (`clerk_auth`) — concurrent `refreshClient()` calls are observed by a counting `HttpService` to have max in-flight of 1.

- `refresh resolving to a freshly minted client must not sign out` (`clerk_auth_state_test.dart`) — the exact observed failure: different id, *newer* timestamp, zero sessions; the timestamp guard alone would not block it.

- `failed refresh must not sign the user out` — 500 on refresh keeps the session.

- `client refresh is suppressed while a deep link is being parsed` — drives a deep link through `config.deepLinkStream` with the nonce exchange held open, and asserts`refreshClient` issues no request until the parse completes (and works again after).

`TestClerkAuthConfig` gained a `deepLinkStream` passthrough to support the last test.

## Verification

- `clerk_auth`: 649 unit + 27 integration tests pass (`dart test`)
- `clerk_flutter`: 784 tests pass (`flutter test`)
- `dart analyze` / `flutter analyze lib`: no issues

## Out of scope / follow-ups

- Dev-instance FAPI answers a stale-rotating-token `GET /client` with 200 + a freshly minted client rather than a 401, which made this failure silent; worth raising with the FAPI team.
- A cold start that arrives mid-OAuth with a rotated persisted token still cannot complete the flow if the initial `createClient` falls back to `POST /client` before the deep-link nonce is seen; presenting the nonce on the initial client fetch would close that gap.
