### PR TITLE
chore: community org metadata and framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Clerk Dart and Flutter SDKs
 
-The official [Clerk](https://clerk.com) Flutter/Dart client library.
+Community-maintained [Clerk](https://clerk.com) Flutter and Dart SDKs — provided as-is, not officially supported by Clerk. See [clerk-community](https://github.com/clerk-community) for what that means.
 
 
 * [clerk_auth](./packages/clerk_auth): Dart SDK

--- a/packages/clerk_auth/README.md
+++ b/packages/clerk_auth/README.md
@@ -2,19 +2,20 @@
 <img src="https://images.clerk.com/static/logo-light-mode-400x400.png" height="90">
 </p>
 
-## Official [Clerk](https://clerk.com) Dart SDK (Beta)
+## Community-maintained [Clerk](https://clerk.com) Dart SDK (Beta)
 
 [![Pub Version](https://img.shields.io/pub/v/clerk_auth?color=blueviolet)](https://pub.dev/packages/clerk_auth)
 [![Pub Points](https://img.shields.io/pub/points/clerk_auth?label=pub%20points)](https://pub.dev/packages/clerk_auth/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
+[![documentation](https://img.shields.io/badge/documentation-docs.page-green.svg)](https://docs.page/clerk-community/clerk-sdk-flutter)
 [![Follow on X](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️
 
-**Clerk helps developers build user management. We provide streamlined user experiences
-for your users to sign up, sign in, and manage their profile from your Dart code.**
+**[Clerk](https://clerk.com) provides user management: sign-up, sign-in, and profile management for your users, straight from your Dart code.**
+
+> This SDK is community-maintained and provided as-is — not officially supported by Clerk. Clerk employees may contribute on their own time. See [clerk-community](https://github.com/clerk-community) for what that means.
 
 ## Requirements
 

--- a/packages/clerk_auth/pubspec.yaml
+++ b/packages/clerk_auth/pubspec.yaml
@@ -1,9 +1,10 @@
 name: clerk_auth
 description: Package that will allow you to authenticate and use Clerk from Dart code.
 version: 0.0.16-beta
-homepage: https://clerk.com/docs
-repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_auth
-issue_tracker: https://github.com/clerk/clerk-sdk-flutter/labels/clerk_auth
+homepage: https://clerk.com
+repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_auth
+documentation: https://docs.page/clerk-community/clerk-sdk-flutter
+issue_tracker: https://github.com/clerk-community/clerk-sdk-flutter/labels/clerk_auth
 topics:
   - authentication
 

--- a/packages/clerk_backend_api/pubspec.yaml
+++ b/packages/clerk_backend_api/pubspec.yaml
@@ -5,8 +5,8 @@
 name: 'clerk_backend_api'
 version: 0.0.16-beta
 description: 'The Clerk REST Backend API. Version 2025-11-10.'
-homepage: 'https://clerk.com/docs'
-repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_backend_api
+homepage: https://clerk.com
+repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_backend_api
 
 environment:
   sdk: '>=3.6.2 <4.0.0'

--- a/packages/clerk_flutter/README.md
+++ b/packages/clerk_flutter/README.md
@@ -2,19 +2,20 @@
 <img src="https://images.clerk.com/static/logo-light-mode-400x400.png" height="90">
 </p>
 
-## Official [Clerk](https://clerk.com) Flutter SDK (Beta)
+## Community-maintained [Clerk](https://clerk.com) Flutter SDK (Beta)
 
 [![Pub Version](https://img.shields.io/pub/v/clerk_flutter?color=blueviolet)](https://pub.dev/packages/clerk_flutter)
 [![Pub Points](https://img.shields.io/pub/points/clerk_flutter?label=pub%20points)](https://pub.dev/packages/clerk_flutter/score)
 [![chat on Discord](https://img.shields.io/discord/856971667393609759.svg?logo=discord)](https://clerk.com/discord)
-[![documentation](https://img.shields.io/badge/documentation-clerk-green.svg)](https://clerk.com/docs)
+[![documentation](https://img.shields.io/badge/documentation-docs.page-green.svg)](https://docs.page/clerk-community/clerk-sdk-flutter)
 [![Follow on X](https://img.shields.io/twitter/follow/clerk?style=social)](https://x.com/intent/follow?screen_name=clerk)
 
 > ### ⚠️ The Clerk Flutter SDK is in Beta ⚠️
 > ❗️ Breaking changes should be expected until the first stable release (1.0.0) ❗️
 
-**Clerk helps developers build user management. We provide streamlined user experiences
-for your users to sign up, sign in, and manage their profile from your Flutter code.**
+**[Clerk](https://clerk.com) provides user management: sign-up, sign-in, and profile management for your users, straight from your Flutter code.**
+
+> This SDK is community-maintained and provided as-is — not officially supported by Clerk. Clerk employees may contribute on their own time. See [clerk-community](https://github.com/clerk-community) for what that means.
 
 ## Requirements
 

--- a/packages/clerk_flutter/pubspec.yaml
+++ b/packages/clerk_flutter/pubspec.yaml
@@ -1,9 +1,10 @@
 name: clerk_flutter
 description: Package that will allow you to authenticate and use Clerk from Flutter code.
 version: 0.0.16-beta
-homepage: https://clerk.com/docs
-repository: https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_flutter
-issue_tracker: https://github.com/clerk/clerk-sdk-flutter/labels/clerk_flutter
+homepage: https://clerk.com
+repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_flutter
+documentation: https://docs.page/clerk-community/clerk-sdk-flutter
+issue_tracker: https://github.com/clerk-community/clerk-sdk-flutter/labels/clerk_flutter
 topics:
   - authentication
 


### PR DESCRIPTION
Now that the SDK lives in the clerk-community org, the language and links should say so. This aligns the repo with the [org's framing](https://github.com/clerk-community): community-maintained, provided as-is, not officially supported by Clerk.

**READMEs** (root, `clerk_flutter`, `clerk_auth`):
- "Official … SDK" headings → "Community-maintained … SDK"
- The first-person-as-Clerk pitch ("Clerk helps developers build user management. We provide…") reworded to third person
- Each package README gains a short as-is notice linking to the [clerk-community profile](https://github.com/clerk-community) — pub.dev visitors see this at the top of the package page
- Documentation badges now point at [docs.page/clerk-community/clerk-sdk-flutter](https://docs.page/clerk-community/clerk-sdk-flutter)

**pubspecs** (`clerk_flutter`, `clerk_auth`, `clerk_backend_api`):
- `homepage` → https://clerk.com (the Flutter docs no longer live under clerk.com/docs)
- `repository` / `issue_tracker` → the clerk-community org
- New `documentation` field → the docs.page site (pub.dev shows this as a sidebar link)

pub.dev picks these up at the next publish — nothing changes on the live package pages until then, so this can merge whenever and ride the next release.

Note: line endings in this repo are mixed per file (root README and `clerk_flutter/pubspec.yaml` are CRLF, the rest LF) — this PR preserves each file's existing convention, so the diffs are content-only. I can submit a follow up PR to fix this once these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
