### PR TITLE
chore: release v0.0.17-beta

### DIFF
--- a/openapi_generator/openapi-generator-config.json
+++ b/openapi_generator/openapi-generator-config.json
@@ -3,7 +3,7 @@
   "input-spec": "https://raw.githubusercontent.com/clerk/openapi-specs/refs/heads/main/bapi/2025-11-10.yml",
   "pubName": "clerk_backend_api",
   "pubDescription": "The Clerk REST Backend API. Version 2025-11-10.",
-  "pubVersion": "0.0.16-beta",
+  "pubVersion": "0.0.17-beta",
   "pubHomepage": "https://clerk.com/docs",
   "pubRepository": "https://github.com/clerk/clerk-sdk-flutter/tree/main/packages/clerk_backend_api"
 }

--- a/packages/clerk_auth/CHANGELOG.md
+++ b/packages/clerk_auth/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.17-beta
+
+* fix: minor fix to new_release tool
+* chore: community org metadata and framing [[#433]](https://github.com/clerk-community/clerk-sdk-flutter/issues/433)
+* test(patrol): sign in with google [[#410]](https://github.com/clerk-community/clerk-sdk-flutter/issues/410)
+* feat: client trust [[#419]](https://github.com/clerk-community/clerk-sdk-flutter/issues/419)
+
 ## 0.0.16-beta
 
 * fix(clerk_auth): offline sign out [[#403]](https://github.com/clerk-community/clerk-sdk-flutter/issues/403)

--- a/packages/clerk_auth/pubspec.yaml
+++ b/packages/clerk_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clerk_auth
 description: Package that will allow you to authenticate and use Clerk from Dart code.
-version: 0.0.16-beta
+version: 0.0.17-beta
 homepage: https://clerk.com
 repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_auth
 documentation: https://docs.page/clerk-community/clerk-sdk-flutter

--- a/packages/clerk_backend_api/CHANGELOG.md
+++ b/packages/clerk_backend_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.17-beta
+
+* fix: minor fix to new_release tool
+* chore: community org metadata and framing [[#433]](https://github.com/clerk-community/clerk-sdk-flutter/issues/433)
+
 ## 0.0.16-beta
 
 * chore: bump `clerk_backend_api` to `0.0.16-beta`

--- a/packages/clerk_backend_api/pubspec.yaml
+++ b/packages/clerk_backend_api/pubspec.yaml
@@ -3,7 +3,7 @@
 #
 
 name: 'clerk_backend_api'
-version: 0.0.16-beta
+version: 0.0.17-beta
 description: 'The Clerk REST Backend API. Version 2025-11-10.'
 homepage: https://clerk.com
 repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_backend_api

--- a/packages/clerk_flutter/CHANGELOG.md
+++ b/packages/clerk_flutter/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.17-beta
+
+* fix: minor fix to new_release tool
+* chore: community org metadata and framing [[#433]](https://github.com/clerk-community/clerk-sdk-flutter/issues/433)
+* test(patrol): sign in with google [[#410]](https://github.com/clerk-community/clerk-sdk-flutter/issues/410)
+* tests: add patrol (#412)
+* feat: client trust [[#419]](https://github.com/clerk-community/clerk-sdk-flutter/issues/419)
+
 ## 0.0.16-beta
 
 * feat(clerk_auth): added immutable to user attribute data [[#406]](https://github.com/clerk-community/clerk-sdk-flutter/issues/406)

--- a/packages/clerk_flutter/pubspec.yaml
+++ b/packages/clerk_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clerk_flutter
 description: Package that will allow you to authenticate and use Clerk from Flutter code.
-version: 0.0.16-beta
+version: 0.0.17-beta
 homepage: https://clerk.com
 repository: https://github.com/clerk-community/clerk-sdk-flutter/tree/main/packages/clerk_flutter
 documentation: https://docs.page/clerk-community/clerk-sdk-flutter
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  clerk_auth: ^0.0.16-beta
+  clerk_auth: 0.0.17-beta
   collection: '>=1.17.1 <2.0.0'
   email_validator: ^3.0.0
   flutter_svg: ^2.0.10+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clerk_sdk
-version: 0.0.16-beta
+version: 0.0.17-beta
 description: >
   Clerk SDK containing all packages that define use of Clerk 
   services for Dart and Flutter code.


### PR DESCRIPTION
This pull request prepares a new `0.0.17-beta` release across the Clerk SDK packages. The main changes are version bumps, changelog updates, and dependency alignment, along with some minor fixes and new features noted in the changelogs.

**Release version updates and dependency alignment:**

* Bumped the version to `0.0.17-beta` in `pubspec.yaml` for all affected packages: `clerk_sdk`, `clerk_auth`, `clerk_backend_api`, and `clerk_flutter` to prepare for the new release. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2) [[2]](diffhunk://#diff-2d1a4fb9b2600f94a18e1a8c915859d03c0cd67c594d5c1405b3728b07e8d77dL3-R3) [[3]](diffhunk://#diff-5c170525df17134a59f9f021cced486868ef611ad59a35a9e18e35a6f38869c9L6-R6) [[4]](diffhunk://#diff-5fbe08b4f48b3455a101f7f85c4652660c2cc098fd18c844e13efe21fcc8f801L3-R3)
* Updated the dependency on `clerk_auth` in `clerk_flutter/pubspec.yaml` to require the new `0.0.17-beta` version.
* Updated the OpenAPI generator config to set `pubVersion` to `0.0.17-beta`.

**Changelog updates and new features:**

* Added `0.0.17-beta` release notes to the changelogs for `clerk_auth`, `clerk_backend_api`, and `clerk_flutter`, including a minor fix to the release tool, community metadata updates, new patrol tests, and the addition of a client trust feature. [[1]](diffhunk://#diff-9b17012aa264025f3b7bb97fc1649b8ca754bcb72b682766ceaa26783f685a07R1-R7) [[2]](diffhunk://#diff-6c742f3988c9212db709b27ae5913de198c4cb003efc01a7d9c6fb53145445f1R1-R5) [[3]](diffhunk://#diff-0938f8af7c6bd7daa48e183a6d1d90a6fbb167d4b9aa5cebc36b7fd90b9c106eR1-R8)